### PR TITLE
Improve performance of three-fiber components

### DIFF
--- a/src/components/Interactive/FaceParticles/FaceParticles.tsx
+++ b/src/components/Interactive/FaceParticles/FaceParticles.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useLoader, useFrame, extend } from 'react-three-fiber';
 import { TextureLoader } from 'three';
 
@@ -10,8 +10,8 @@ import { Particles } from './objects/particles';
 extend({ ParticlesMaterial, Particles });
 
 const FaceParticles = () => {
-  const [time, setTime] = useState(0);
   const particles = useRef<Particles>(null);
+  const particlesMaterialRef = useRef<ParticlesMaterial>(null);
   const { textureUrl } = useStore((state) => state.face);
   const particleTexture = useLoader(TextureLoader, textureUrl);
 
@@ -20,7 +20,9 @@ const FaceParticles = () => {
   }, []);
 
   useFrame((_, delta) => {
-    setTime(time + delta);
+    if (particlesMaterialRef.current) {
+      particlesMaterialRef.current.update(delta);
+    }
   });
 
   return (
@@ -28,8 +30,8 @@ const FaceParticles = () => {
       <mesh name="particles" position={[75, 0, 0]}>
         <particles args={[particleTexture]} attach="geometry" ref={particles} />
         <particlesMaterial
+          ref={particlesMaterialRef}
           attach="material"
-          time={time}
           particleTexture={particleTexture}
           extensions-derivatives
         />

--- a/src/components/Interactive/FaceParticles/materials/particles.ts
+++ b/src/components/Interactive/FaceParticles/materials/particles.ts
@@ -64,7 +64,7 @@ export class ParticlesMaterial extends RawShaderMaterial {
     );
   }
 
-  set time(time: number) {
-    this.uniforms.time.value = time;
+  public update(delta: number) {
+    this.uniforms.time.value += delta;
   }
 }

--- a/src/components/Interactive/Fog/Fog.tsx
+++ b/src/components/Interactive/Fog/Fog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useLoader, useFrame, extend } from 'react-three-fiber';
 import { TextureLoader } from 'three';
 
@@ -11,7 +11,7 @@ extend({ CloudsMaterial, Clouds });
 
 const Fog = () => {
   const clouds = useRef<Clouds>(null);
-  const [time, setTime] = useState(0.0);
+  const cloudsMaterialRef = useRef<CloudsMaterial>(null);
   const { textureUrl } = useStore((state) => state.fog);
   const cloudTexture = useLoader(TextureLoader, textureUrl);
 
@@ -20,7 +20,9 @@ const Fog = () => {
   }, []);
 
   useFrame((_, delta) => {
-    setTime(time + delta);
+    if (cloudsMaterialRef.current) {
+      cloudsMaterialRef.current.update(delta);
+    }
   });
 
   return (
@@ -28,9 +30,9 @@ const Fog = () => {
       <mesh name="fog" position={[0, 0, -700]}>
         <clouds args={[20]} ref={clouds} attach="geometry" />
         <cloudsMaterial
+          ref={cloudsMaterialRef}
           attach="material"
           cloudTexture={cloudTexture}
-          time={time}
           extensions-derivatives
         />
       </mesh>

--- a/src/components/Interactive/Fog/materials/clouds.ts
+++ b/src/components/Interactive/Fog/materials/clouds.ts
@@ -32,7 +32,7 @@ export class CloudsMaterial extends RawShaderMaterial {
     this.uniforms.cloudTexture.value = texture;
   }
 
-  set time(value: number) {
-    this.uniforms.time.value = value;
+  public update(delta: number) {
+    this.uniforms.time.value += delta;
   }
 }


### PR DESCRIPTION
So in react, you'd normally want your components to re-render when *state* changes and this is done by utilising *setState*. Whilst this is perfectly fine with most React applications, when using THREE.js it can cause some performance issues especially if the tree is deep, due to the render loop running ~60 times per second! The optimal way is to mutate the THREE object instances in which the new state will be picked up on the next tick thus skipping a massive full component re-render 👍 