### PR TITLE
Wire varlock runtime integration (schema-driven env loading)

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -31,10 +31,12 @@ FORTUNE_STUB=
 REDIS_URL=
 
 # Sentry (refactor Phase 7) — absent = no telemetry (init is gated on the DSN).
-# Server errors read SENTRY_DSN at runtime (sensitive, server-only); the browser
-# SDK reads NEXT_PUBLIC_SENTRY_DSN at BUILD time (public — ships in the client
-# bundle by design, so NOT sensitive).
-# @sensitive @optional
+# A Sentry DSN is NOT a secret: it's write-only (submits events, can't read them)
+# and is embedded in client apps by design. Both vars carry the same DSN value,
+# and the NEXT_PUBLIC_ one ships it in the client bundle — so marking SENTRY_DSN
+# sensitive makes varlock's leak scan (correctly) find that value in the bundle
+# and fail the build. Both are non-sensitive.
+# @sensitive=false @optional
 SENTRY_DSN=
 # @optional
 NEXT_PUBLIC_SENTRY_DSN=

--- a/.env.schema
+++ b/.env.schema
@@ -2,6 +2,13 @@
 # This file is COMMITTED — it declares every env var, never values.
 # Real values live in .env.local (gitignored) and Vercel project settings.
 # Validate resolved env anytime with: pnpm env:check
+#
+# Sensitivity defaults from the NEXT_PUBLIC_ prefix: NEXT_PUBLIC_* are public
+# (shipped to the client by design), everything else is sensitive. varlock's
+# post-build leak scan checks that no sensitive VALUE lands in the build output,
+# so non-secret toggles must be marked @sensitive=false or their value (e.g. "1")
+# matches everywhere and fails the build.
+# @defaultSensitive=inferFromPrefix('NEXT_PUBLIC_')
 # ---
 
 # Madame Zara (the fortune-teller attraction, /api/fortune).
@@ -11,7 +18,8 @@
 ANTHROPIC_API_KEY=
 
 # Force stub mode even with a key present (dev / headless verification).
-# @optional
+# A non-secret boolean toggle — not sensitive (its value is scanned otherwise).
+# @sensitive=false @optional
 FORTUNE_STUB=
 
 # Cross-instance rate limiting (optional future upgrade) — absent = the current
@@ -23,8 +31,9 @@ FORTUNE_STUB=
 REDIS_URL=
 
 # Sentry (refactor Phase 7) — absent = no telemetry (init is gated on the DSN).
-# Server errors read SENTRY_DSN at runtime; the browser SDK reads
-# NEXT_PUBLIC_SENTRY_DSN at BUILD time (must be set in the deploy env to activate).
+# Server errors read SENTRY_DSN at runtime (sensitive, server-only); the browser
+# SDK reads NEXT_PUBLIC_SENTRY_DSN at BUILD time (public — ships in the client
+# bundle by design, so NOT sensitive).
 # @sensitive @optional
 SENTRY_DSN=
 # @optional

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -40,6 +40,9 @@ suite is flaky under headless SwiftShader and is run locally with
 
 Set these in **Vercel → Project → Settings → Environment Variables**. See
 `.env.schema` for the canonical list (`pnpm env:check` validates locally).
+**varlock** owns env loading at runtime (it replaces Next's internal `@next/env`
+via a pnpm override), so `.env.schema` is enforced on every build, `@sensitive`
+values are redacted from logs, and env leaks are caught at build + runtime.
 
 | Variable                 | Enables                               | Notes                                                                  |
 | ------------------------ | ------------------------------------- | ---------------------------------------------------------------------- |

--- a/next.config.ts
+++ b/next.config.ts
@@ -46,7 +46,6 @@ const withSentry = process.env.SENTRY_DSN
       silent: true,
       // Source-map upload needs SENTRY_ORG/PROJECT/AUTH_TOKEN; skipped until set.
       widenClientFileUpload: true,
-      disableLogger: true,
     })
   : nextConfig;
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,13 @@
 import type { NextConfig } from 'next';
 import { withSentryConfig } from '@sentry/nextjs';
+import { varlockNextConfigPlugin } from '@varlock/nextjs-integration/plugin';
 
-// varlock is adopted schema-first (refactor Phase 3): .env.schema declares the
-// env surface and `pnpm env:check` validates it (redacted output). The runtime
-// integration (@next/env override + plugin) is DEFERRED: its @next/env swap
-// needs pnpm overrides, which pnpm 11 only reads from pnpm-workspace.yaml —
-// gitignored here for Vercel. Flip once a preview deploy proves a committed
-// workspace file is safe (docs/refactor-plan.md Phase 3).
+// varlock owns env loading: the `next>@next/env` override (pnpm-workspace.yaml)
+// swaps Next's internal loader for varlock's, and this plugin wires it in. So
+// .env.schema is the source of truth — validated at build, secrets redacted
+// from logs, and env leaks caught at build + runtime. (Needed Corepack so
+// Vercel reads the pnpm override; see docs/DEPLOY.md.)
+const withVarlock = varlockNextConfigPlugin();
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -38,9 +39,9 @@ const nextConfig: NextConfig = {
   },
 };
 
-// Wrap with Sentry only when a DSN is present at build (Vercel, once configured).
-// Without it the build is untouched — no Sentry footprint until credentials land.
-export default process.env.SENTRY_DSN
+// Wrap with Sentry only when a DSN is present at build (Vercel, once configured);
+// without it the build is untouched. varlock wraps the result either way.
+const withSentry = process.env.SENTRY_DSN
   ? withSentryConfig(nextConfig, {
       silent: true,
       // Source-map upload needs SENTRY_ORG/PROJECT/AUTH_TOKEN; skipped until set.
@@ -48,3 +49,5 @@ export default process.env.SENTRY_DSN
       disableLogger: true,
     })
   : nextConfig;
+
+export default withVarlock(withSentry);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@react-three/fiber": "^9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "@sentry/nextjs": "^10.65.0",
+    "@varlock/nextjs-integration": "1.1.4",
     "@vercel/analytics": "^2.0.1",
     "ai": "^7.0.22",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  next>@next/env: npm:@varlock/nextjs-integration
+
 importers:
 
   .:
@@ -25,10 +28,13 @@ importers:
         version: 3.0.4(@react-three/fiber@9.6.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.1))(@types/three@0.185.0)(react@19.2.7)(three@0.185.1)
       '@sentry/nextjs':
         specifier: ^10.65.0
-        version: 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.108.4)
+        version: 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(react@19.2.7)(webpack@5.108.4)
+      '@varlock/nextjs-integration':
+        specifier: 1.1.4
+        version: 1.1.4(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(varlock@1.10.0)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(react@19.2.7)
       ai:
         specifier: ^7.0.22
         version: 7.0.22(zod@4.4.3)
@@ -46,7 +52,7 @@ importers:
         version: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: ^16.2.10
-        version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0)
       rate-limiter-flexible:
         specifier: ^11.2.0
         version: 11.2.0
@@ -649,9 +655,6 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
-
-  '@next/env@16.2.10':
-    resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
 
   '@next/swc-darwin-arm64@16.2.10':
     resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
@@ -1692,6 +1695,13 @@ packages:
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
       react: '>= 16.8.0'
+
+  '@varlock/nextjs-integration@1.1.4':
+    resolution: {integrity: sha512-mARAT7jkAIuSlKeI4JHhVno/0FySTwJHuJsl0nHOxrnmficnHvUhXq7paUONMCoKOc4yrPp67yH4AkUskrpnEw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      next: '>=14'
+      varlock: ^1.10.0
 
   '@vercel/analytics@2.0.1':
     resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
@@ -4455,8 +4465,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@next/env@16.2.10': {}
-
   '@next/swc-darwin-arm64@16.2.10':
     optional: true
 
@@ -4966,7 +4974,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.65.0
 
-  '@sentry/nextjs@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.108.4)':
+  '@sentry/nextjs@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(react@19.2.7)(webpack@5.108.4)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -4979,7 +4987,7 @@ snapshots:
       '@sentry/react': 10.65.0(react@19.2.7)
       '@sentry/vercel-edge': 10.65.0
       '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.108.4)
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -5331,9 +5339,14 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.7
 
-  '@vercel/analytics@2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@varlock/nextjs-integration@1.1.4(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(varlock@1.10.0)':
+    dependencies:
+      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0)
+      varlock: 1.10.0
+
+  '@vercel/analytics@2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(react@19.2.7)':
     optionalDependencies:
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0)
       react: 19.2.7
 
   '@vercel/oidc@3.2.0': {}
@@ -6754,9 +6767,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0):
     dependencies:
-      '@next/env': 16.2.10
+      '@next/env': '@varlock/nextjs-integration@1.1.4(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(varlock@1.10.0)'
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.36
       caniuse-lite: 1.0.30001799
@@ -6779,6 +6792,7 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+      - varlock
 
   node-exports-info@1.6.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,13 @@
-# Not a real workspace — carries pnpm's build-script approvals only.
+# Not a real workspace — carries pnpm settings only.
 # Everywhere uses pnpm 11 (local + CI via packageManager; Vercel via Corepack,
-# ENABLE_EXPERIMENTAL_COREPACK=1), which reads approvals from `allowBuilds`.
-# Committed so every environment approves these native builds identically.
+# ENABLE_EXPERIMENTAL_COREPACK=1), which reads these settings here.
+# Committed so every environment behaves identically.
 allowBuilds:
   sharp: true # next/image optimization
   '@sentry/cli': true # source-map upload during build (when Sentry is configured)
+
+# varlock runtime integration: replace Next's internal env loader with varlock's
+# so .env.schema drives loading + validation + @sensitive redaction + leak
+# detection. pnpm 11 reads overrides from here (this is why it needed Corepack).
+overrides:
+  next>@next/env: npm:@varlock/nextjs-integration


### PR DESCRIPTION
Completes the varlock adoption that Phase 3 left half-done. Until now varlock only did **schema validation** (`.env.schema` + `pnpm env:check`); the runtime integration was deferred because the `@next/env` override it needs couldn't reach Vercel (pnpm read overrides only from the gitignored workspace file).

**Enabling Corepack on Vercel + committing `pnpm-workspace.yaml` removed that blocker**, so this wires up the rest:

- pnpm override `next>@next/env` → `@varlock/nextjs-integration` (in `pnpm-workspace.yaml`)
- `varlockNextConfigPlugin()` in `next.config.ts`, composed with the existing conditional Sentry wrapper

Now varlock **replaces Next's internal env loader**, so `.env.schema` is enforced on every build, `@sensitive` values are redacted from logs, and env leaks are caught at build + runtime — not just in the CI `env:check` step.

## Verification

Build prints `✨ loaded by varlock ✨` and compiles. Locally green: typecheck, 73 unit/component tests, `pnpm env:check`, lint, knip. Runtime confirmed — the stub fortune route streams correctly, so env loading is intact through varlock. CI + a Vercel preview will exercise it end-to-end (the override now applies on Vercel via Corepack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
