### PR TITLE
fix: mobile ticket-chip/striker HUD collision + carousel rainbow floor

### DIFF
--- a/src/components/overlays/TicketHud.tsx
+++ b/src/components/overlays/TicketHud.tsx
@@ -22,8 +22,12 @@ export function TicketHud() {
   const celebrate = useSceneStore((s) => s.celebrateTickets);
   const resetTickets = useSceneStore((s) => s.resetTickets);
   const started = useSceneStore((s) => s.started);
+  const playing = useSceneStore((s) => s.mode === 'playing');
 
-  const showChip = started && found > 0;
+  // Hide the tally while a game owns the screen — the high striker's stats hug
+  // the same bottom edge and the two collided on mobile (same pattern as
+  // SiteNav's burger: game chrome wins, the chip fades back on exit).
+  const showChip = started && !playing && found > 0;
   const showModal = started && found >= TICKET_COUNT && !celebrated;
 
   return (

--- a/src/components/three/synty/AnimatedRides.tsx
+++ b/src/components/three/synty/AnimatedRides.tsx
@@ -53,7 +53,14 @@ function Ride({
     const c = scene.clone(true);
     c.traverse((o) => {
       const m = o as Mesh;
-      if (m.isMesh && m.material) applyEmissive(m.material, emissive, emissiveIntensity);
+      if (!m.isMesh || !m.material) return;
+      // Only materials in the shared-atlas UV space may take the emissive atlas.
+      // The carousel + swing chairs carry a second 'WoodFloor' material with its
+      // OWN texture/UV layout — its UVs land on the emissive atlas's lit swatch
+      // strip, painting glowing rainbow rectangles across the floor.
+      for (const mat of Array.isArray(m.material) ? m.material : [m.material]) {
+        if (mat.name.includes('HorrorCarnival')) applyEmissive(mat, emissive, emissiveIntensity);
+      }
     });
     return c;
   }, [scene, emissive, emissiveIntensity]);


### PR DESCRIPTION
Two visual bugs reported by Nick:

## 1. Ticket tally vs High Striker HUD collision (mobile)

The golden-ticket chip (bottom-left) collided with the striker's stats, which deliberately hug the same bottom edge (the pole + bell own the screen centre/top). The chip now **hides while `mode === 'playing'`** — the established pattern (SiteNav's burger does the same): game chrome wins, the tally fades back on exit. Ball toss was never affected (its chrome is top-centre).

Headless mobile-viewport check: chip visible exploring → hidden during striker → returns on exit. ✅

## 2. Rainbow patches on the carousel floor

Root cause found in the GLB data: the carousel (and swing chairs) carry **two materials** — `HorrorCarnival_01_A` (the standard atlas) and `WoodFloor`, a separate wood texture with its **own UV layout**. `AnimatedRides` blanket-applied the shared emissive atlas to every material, so the floor's UVs landed on the atlas's lit swatch strip → glowing rainbow rectangles. (The teacup has only the atlas material, which is why it was clean.)

Emissive is now applied only to materials in the shared-atlas UV space; the rides' real neon keeps glowing and the floors render their wood.

**Proof:** deterministic-camera A/B pixel diff — 3,622 changed pixels, all inside the carousel platform (the exact rainbow patches), canopy/horses/bulbs untouched.

Gate: typecheck, lint, 73 tests, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
