### PR TITLE
feat: doodle wall — Stage 1, the visitor path

### DIFF
--- a/.claude/agents/carnival-context.md
+++ b/.claude/agents/carnival-context.md
@@ -1,0 +1,58 @@
+---
+name: carnival-context
+description: Context keeper for multi-agent feature work on iamnick.dev. Owns the feature's living handoff doc (docs/redesign/<feature>-handoff.md) — the single source of truth every builder agent is briefed from. Use it BEFORE delegating a slice (to produce a brief) and AFTER a slice lands (to fold the outcome back in). Read-only on code; read/write on the handoff doc only.
+tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+You are the context keeper for iamnick.dev — the agent that keeps the full
+picture in motion while feature work is delegated across many sub-agents and
+sessions. You do not write feature code. Your one writable artefact is the
+feature's living handoff doc in `docs/redesign/` (currently
+`doodle-wall-handoff.md`); everything else you touch is read-only.
+
+On every invocation, in order:
+
+1. Read `CONTEXT.md` (glossary — its language is law; respect every `_Avoid_`
+   list), the living handoff doc, `docs/redesign/STATUS.md`, and any ADR the
+   handoff doc names as binding.
+2. Verify the handoff doc against reality before trusting it: check the git
+   log since the doc's last update (`git log --oneline`) and spot-check that
+   named files/exports still exist. Never brief from stale claims.
+
+You are called in one of two modes; the orchestrator names which:
+
+**Brief** — produce a self-contained mission brief for one builder slice.
+Include: the slice's goal in one sentence; exact files to create/modify (and
+what NOT to touch); binding decisions with their source (ADR number, grill
+outcome, Nick's word); the architectural rules that bind the slice (hexagonal
+boundaries — routes are thin adapters, domain services in `src/lib/doodle-wall/`
+against ports, supabase-js only inside `src/lib/supabase/` adapters); which
+skills the builder MUST consult (`supabase` + `supabase-postgres-best-practices`
+for any Supabase work, `security-best-practices` for any API surface, the
+relevant `r3f-*` skill for canvas work); the verification recipe for the slice;
+and the gotchas from the handoff doc that apply. The builder gets ONLY the
+brief — assume it has read nothing else, but tell it to read `CONTEXT.md`
+first.
+
+**Absorb** — after a slice lands (or fails), fold the outcome into the handoff
+doc: update "current state" and "what just happened", record new decisions with
+who made them, add newly discovered gotchas, strike work now done, and adjust
+the build order if reality diverged from plan. Keep the doc tight — it is a
+working document, not a log; supersede rather than append. Flag, in a clearly
+marked **Needs Nick** section, any decision that belongs to Nick (visual feel,
+copy, provisioning, anything touching money or accounts) — never resolve those
+yourself.
+
+Non-negotiables:
+
+- Glossary terms exactly: doodle wall, tile, pre-moderation queue, stall,
+  step-in, Full/Lite, overlay, HUD, Midway, attraction. Banned synonyms never
+  appear, even in prose.
+- The handoff doc's structure follows the house pattern (see
+  `ball-toss-game-handoff.md`): TL;DR → current state → integration map →
+  spec → decisions → verification → gotchas → build order → what just
+  happened.
+- Style: tight, factual, comment-register prose; British English; no
+  marketing fluff, no emoji.
+- Return to the orchestrator a short summary: mode, what you read, what you
+  wrote (brief text or doc sections updated), and anything in **Needs Nick**.

--- a/.env.schema
+++ b/.env.schema
@@ -30,6 +30,25 @@ FORTUNE_STUB=
 # @sensitive @optional
 REDIS_URL=
 
+# Doodle wall backend (ADR-0001, /api/tiles + /api/wall). With ANY of the
+# three Supabase vars absent, both routes run in stub mode against in-memory
+# fakes (seeded wall, per-instance submissions) — dev, CI, and the
+# currently-unprovisioned production all run keyless. The anon key is unused
+# by this slice; it is declared now for Stage 2 admin (moderation) auth.
+# @sensitive @optional
+SUPABASE_URL=
+# @sensitive @optional
+SUPABASE_ANON_KEY=
+# @sensitive @optional
+SUPABASE_SERVICE_ROLE_KEY=
+
+# HMAC secret behind submitter hashes (abuse tracing without raw IPs at
+# rest). In stub mode a fixed dev constant stands in; once the Supabase env
+# is present this MUST be set — the routes fail loudly rather than persist
+# hashes minted under a public constant.
+# @sensitive @optional
+SUBMITTER_HASH_SECRET=
+
 # Sentry (refactor Phase 7) — absent = no telemetry (init is gated on the DSN).
 # A Sentry DSN is NOT a secret: it's write-only (submits events, can't read them)
 # and is embedded in client apps by design. Both vars carry the same DSN value,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,7 +45,7 @@ Any DOM UI layered over the canvas — content panels, the intro veil, HUDs. The
 _Avoid_: modal (only some overlays are modal), popup, layer
 
 **HUD**:
-An in-game or status overlay — the ball-toss and high-striker game panels and the golden-ticket tally. A subset of overlays; the `Hud` suffix and `hud-*` styling are reserved for these.
+An in-game or status overlay — the ball-toss, high-striker and doodle wall game panels and the golden-ticket tally. A subset of overlays; the `Hud` suffix and `hud-*` styling are reserved for these.
 _Avoid_: game UI, scoreboard, widget
 
 **Ball-toss**:
@@ -75,3 +75,7 @@ _Avoid_: cell, square, slot, post
 **Pre-moderation queue**:
 The holding area every submitted tile enters. Nick reviews and approves/rejects each one; unapproved tiles are never shown publicly.
 _Avoid_: review board, moderation inbox
+
+**The carny**:
+The unseen stallholder persona the doodle wall's copy hands a submitted tile to ("your tile is with the carny") — the in-world face of the pre-moderation queue. Purely narrative; the actual moderator is Nick.
+_Avoid_: moderator (in visitor-facing copy), attendant, admin (as a character)

--- a/docs/adr/0001-doodle-wall-supabase-backend.md
+++ b/docs/adr/0001-doodle-wall-supabase-backend.md
@@ -2,6 +2,20 @@
 
 The doodle wall (a communal stall where visitors draw tiles others can see) turns the previously static, backend-free portfolio into one with a writable, persisted store. We will use **Supabase** — Postgres for tile rows + status, Storage for the small PNG tile images, and Supabase Auth (Google OAuth) for the single-moderator admin view — chosen because Nick already runs Supabase in other projects and it bundles database, storage, and auth in one free tier. Tiles are **persisted, not live**; the wall shows a bounded set of the most recent **approved** tiles; every submission lands in a **pre-moderation queue** that only Nick can approve before anything is shown publicly.
 
+## Revision (2026-07-14 — Stage 1 implemented, decision reaffirmed)
+
+Stage 1 (the visitor path) shipped on the current Next.js 16 / Vercel stack:
+`POST /api/tiles` + `GET /api/wall` over a Supabase-agnostic domain layer
+(`src/lib/doodle-wall/`) with the Supabase adapters (`src/lib/supabase/`)
+dormant — both routes run in stub mode against in-memory fakes until Nick
+provisions the project, at which point the committed migration
+(`supabase/migrations/20260714115029_doodle_wall.sql`) is applied. One
+tightening of the original sketch: the RLS policies grant **no anon insert**
+— every write goes through the service role, so RLS is a read backstop, not
+the submission path, and a leaked anon key cannot flood the queue past the
+service's checks. Admin gating (the allow-listed moderation view) and the
+keepalive cron remain Stage 2, not built.
+
 ## Considered options
 
 - **Vercel-native** (Vercel Postgres/Neon + Vercel Blob) — single platform, but rejected in favour of Nick's existing Supabase familiarity.

--- a/docs/redesign/STATUS.md
+++ b/docs/redesign/STATUS.md
@@ -2,9 +2,10 @@
 
 > **Start here for a new session.** What the shipped scene is, how it's built,
 > how to verify a change, and what's in flight. Companions: `CONTEXT.md`
-> (glossary — use its language), `docs/refactor-plan.md` (the standards refactor
-> now executing), `docs/CODE_QUALITY_AUDIT.md` (July 2026 audit), the ADRs
-> (locked decisions), and `scene-map-guide.md` (authoring NPC/walker placements).
+> (glossary — use its language), `docs/refactor-plan.md` (the standards
+> refactor, complete and merged), `docs/CODE_QUALITY_AUDIT.md` (July 2026
+> audit), the ADRs (locked decisions), and `scene-map-guide.md` (authoring
+> NPC/walker placements).
 
 ## Where we are
 
@@ -15,12 +16,14 @@ indicators over each attraction; clicking one flies the camera in and opens
 that attraction's content overlay. The earlier first-person on-rails walk
 (ADR-0004) was reversed in the iso pivot; free-roam is the shipped design.
 
-Live on top of the scene: two playable stalls (ball-toss, high-striker), a
-golden-ticket hunt, Madame Zara's fortune wagon (`/api/fortune`,
-Anthropic-backed with a keyless stub mode), a letterpress-carnival HUD
-language, and Full/Lite quality tiers plus a no-canvas tier — under
-`prefers-reduced-motion` the sr-only `StaticCv` (the CV as DOM) becomes the
-visible page (ADR-0003).
+Live on top of the scene: three playable stalls — ball-toss, high-striker,
+and the doodle wall (Stage 1, the visitor path: view + draw on Full and Lite;
+its API runs in stub mode until Supabase is provisioned) — a golden-ticket
+hunt, Madame Zara's fortune wagon (`/api/fortune`, Anthropic-backed with a
+keyless stub mode), a letterpress-carnival HUD language, and Full/Lite quality
+tiers plus a no-canvas tier — under `prefers-reduced-motion` the sr-only
+`StaticCv` (the CV as DOM) becomes the visible page (ADR-0003), where the
+doodle wall stays reachable via its `#doodle-wall` anchor.
 
 ## Scene architecture (files)
 
@@ -31,7 +34,8 @@ Entry chain — `src/app/page.tsx` mounts client islands over a server page:
   (Full/Lite) /`none` (reduced-motion / no WebGL → no canvas at all).
 - **`src/components/three/Scene.tsx`** — the single persistent R3F canvas:
   exp² fog + ACES tone mapping, `SyntyScene`, `AnimatedRides`, `BulbGlow`,
-  `DynamicLights`, `Npcs`, `Atmosphere`, `GoldenTickets`, both games,
+  `DynamicLights`, `Npcs`, `Atmosphere`, `GoldenTickets`, both game sims,
+  `DoodleWall` (the stall's tile board),
   `LoaderVeil` (shader loading veil) and `SafePostFX` (bloom, mounted only
   after the veil dissolves; a persisted context-loss tripwire can disable it
   per-device). Header comments in the file explain the bloom/veil ordering and
@@ -42,9 +46,10 @@ Entry chain — `src/app/page.tsx` mounts client islands over a server page:
   base atlas, normal sanitising), `SyntyScene` (renders
   `demo-instances.json` + `manifest.json` + `sceneAdditions.ts`, with exclusion
   filters for translation artefacts).
-- **`synty/attractions.ts`** — **the single source of truth for POIs.** Eight
+- **`synty/attractions.ts`** — **the single source of truth for POIs.** Nine
   attractions: `intro`, `about`, `work`, `projects`, `contact`,
-  `high-striker`, `fortune`, `ball-toss`. Each carries its prefab, authored
+  `high-striker`, `fortune`, `ball-toss`, `doodle-wall`. Each carries its
+  prefab, authored
   Unity transform, world-centre `position` (indicator anchor + camera focus
   target), `facing` and `focusDist`. Indicators, camera fly-ins, SiteNav links
   and overlay routing all derive from this array.
@@ -53,8 +58,12 @@ Entry chain — `src/app/page.tsx` mounts client islands over a server page:
   touch), scroll/pinch zoom (clamped), and the fly-in/return easing when
   `focusedAttraction` changes.
 - **Games** — `three/game/BallTossGame.tsx` (slingshot pull-back throw, tuning
-  in `ballTossConfig.ts`) and `three/game/HighStrikerGame.tsx`
-  (`highStrikerConfig.ts`); `three/tickets/GoldenTickets.tsx` for the hunt.
+  in `ballTossConfig.ts`), `three/game/HighStrikerGame.tsx`
+  (`highStrikerConfig.ts`) and `three/game/DoodleWall.tsx` (the doodle wall's
+  board at the end of the Midway — the newest approved tiles from `/api/wall`
+  as a 6×4 grid; layout/tools tuning in `doodleWallConfig.ts`, a three-free
+  module that re-exports the server truths from `lib/doodle-wall/constants.ts`);
+  `three/tickets/GoldenTickets.tsx` for the hunt.
 
 ## Overlay layer (DOM over the canvas)
 
@@ -69,10 +78,17 @@ tests colocated, no barrels — the Phase 2 conventions in
   **`FortunePanel.tsx`** (streams Readings from `/api/fortune`), and the
   career attraction opens **`CareerTickets.tsx`** (the ticket deck) on its
   own stage.
-- **Game HUDs** — `overlays/BallTossHud.tsx`, `overlays/HighStrikerHud.tsx`
-  and `overlays/TicketHud.tsx`: DOM overlays mounted from `page.tsx`. Their
-  tuning configs stay canvas-side (`three/game/ballTossConfig.ts`,
-  `three/game/highStrikerConfig.ts`, `three/tickets/ticketConfig.ts`).
+- **Game HUDs** — `overlays/BallTossHud.tsx`, `overlays/HighStrikerHud.tsx`,
+  `overlays/DoodleWallHud.tsx` and `overlays/TicketHud.tsx`: DOM overlays
+  mounted from `page.tsx`. Their tuning configs stay canvas-side
+  (`three/game/ballTossConfig.ts`, `three/game/highStrikerConfig.ts`,
+  `three/game/doodleWallConfig.ts`, `three/tickets/ticketConfig.ts`).
+  `DoodleWallHud` is the doodle wall's step-in overlay — the approved-tile
+  wall view plus the drawing surface (512×512 canvas exported as a 256×256
+  PNG to `POST /api/tiles`), with the carny fronting the pre-moderation queue
+  in its copy. It opens on step-in on both Full and Lite, and `StaticCv`'s
+  `#doodle-wall` hash link is routed through `stepIn()` too, so the no-canvas
+  tier reaches the same overlay.
 - **`IntroOverlay`, `AudioDirector`, `DebugBridge`** (`overlays/`) — entry
   vignette, scene-state→audio mixer, and the headless-verification hook.
 - **`src/components/cv/`** — server-only: `StaticCv.tsx` (the sr-only CV
@@ -95,9 +111,11 @@ An eslint `no-restricted-imports` rule bans `@/content/cv` from client code
 - `playing` — stepped into a stall; input drives the game until `exit()`.
 
 Plus: intro/veil progress flags, `focusedAttraction`/`activeAttraction`/
-`activeStall`, persisted `postFxBlocked`/`muted`/ticket progress, and summary
+`activeStall`, persisted `postFxBlocked`/`muted`/ticket progress, summary
 slices for both games (the physics lives in refs; only HUD-facing summaries hit
-the store). Per-frame consumers read imperatively via
+the store), and the doodle wall's `doodleWallPhase`
+(`intro | drawing | submitting | submitted | error`, reset to `intro` on
+step-in). Per-frame consumers read imperatively via
 `useSceneStore.getState()` inside `useFrame` so updates never re-render React.
 
 ## How to verify a change
@@ -124,8 +142,10 @@ states come from the debug hooks, all inert without `?debug=1`:
 
 - `window.__sceneStore` (via `DebugBridge`) — drive the store directly:
   `__sceneStore.getState().start()`, `.focus('fortune')`, etc.
-- `?off=synty,rides,glow,lights,game,indicators` and `?offp=<regex>` — Scene.tsx
-  bisection gates for unmounting pieces/prefabs.
+- `?off=synty,rides,glow,lights,atmo,postfx,game,doodle,tickets,npcs,indicators`
+  and `?offp=<regex>` — Scene.tsx bisection gates for unmounting
+  pieces/prefabs (`doodle` unmounts the doodle wall board on its own; `game`
+  covers the ball-toss and high-striker sims).
 - `?bloom=0` — force the composer off for A/B comparison.
 
 Headless swiftshader colour/fps is unreliable — real-GPU eyeballs remain the
@@ -133,28 +153,41 @@ final judge for grading changes.
 
 ## What just happened
 
-**Refactor Phase 2 — component architecture** (see `docs/refactor-plan.md` for
-the full plan; all phases have since merged to master). Components moved into role-based
-folders: `components/content/` → `overlays/`, the three game HUDs left the
-three tree for `overlays/` (configs stayed canvas-side), `cv/` was created for
-the server-only CV document — `StaticResume` renamed `StaticCv` (component and
-`.static-cv` class) alongside `JsonLd` — and fonts moved to
-`src/lib/fonts/{local,google}.ts`. `organisms/` and `ui-modules/` no longer
-exist. The cv-import ban is enforced by eslint. Conventions are codified in
-`docs/redesign/architecture.md`. Phase 1 (dead-code purge: the retired
-first-person scene, the dormant organisms/section layer, vestigial store
-fields; ADR-0007 supersedes ADR-0004) landed immediately before.
+**Doodle wall, Stage 1 — the visitor path** (`feature/doodle-wall`,
+2026-07-14). The communal stall now closes the Midway. A hexagonal slice:
+domain layer in `src/lib/doodle-wall/` (`tileService` holding every acceptance
+rule, ports, PNG header validation, HMAC submitter hashing, in-memory fakes),
+dormant Supabase adapters in `src/lib/supabase/` (`tileAdapters.ts` is the
+single selection point — a fully keyless env is stub mode against the fakes;
+a _partially_ set Supabase env in production throws instead of silently
+serving fakes), `POST /api/tiles` + `GET /api/wall`, a reviewed-only migration
+(`supabase/migrations/20260714115029_doodle_wall.sql` — anon may read approved
+tiles only; there is **no anon insert policy**, every write goes through the
+service role), four new `.env.schema` vars, the in-scene board
+(`three/game/DoodleWall.tsx`), the `DoodleWallHud` step-in overlay and the
+`doodle-wall` attraction plus `StaticCv`'s `#doodle-wall` anchor. **Stage 2 —
+the admin moderation view and the keepalive cron — is not built**, and the
+Supabase project is not yet provisioned: both routes run in stub mode
+everywhere.
 
-## What's next (refactor phases, one line each)
+Before that, the **standards refactor** completed and merged to master
+(PRs #60–64; `docs/refactor-plan.md` is now historical). Its Phase 2 still
+shapes the tree: role-based component folders (`components/content/` →
+`overlays/`, game HUDs out of the three tree, `cv/` for the server-only CV
+document, `StaticResume` renamed `StaticCv`), fonts in
+`src/lib/fonts/{local,google}.ts`, the eslint cv-import ban, and the
+conventions codified in `docs/redesign/architecture.md`.
 
-2. **Component architecture** — DONE (see above).
-3. **Config/deps/secrets** — pin the `"latest"` deps, varlock `.env.schema`, App Router cleanups.
-4. **Fortune API + a11y** — zod body schema, Vercel AI SDK transport, Upstash rate limiting, modal focus traps.
-5. **Dedup & extraction** — single homes for `EASE`/atlas-texture/GLSL-noise duplicates, `useDisposable()`.
-6. **Tests & tooling** — unit gaps (`unityTRS`, audio), Playwright e2e absorbing the `/tmp/shot` rig, knip in CI.
-7. **Ops hardening** — Sentry, Renovate, Vercel Analytics.
+## What's next
 
-Beyond the refactor (tracked in the audit/plan, not standards work): the Synty
-atlas dedup (~17 MB → ~2 MB model payload — the biggest user-facing win),
-keyboard navigation for scene and games, and Madame Zara persona QA before the
-fortune-teller branch merges.
+- **Supabase provisioning** (Nick) — create the project, apply
+  `supabase/migrations/20260714115029_doodle_wall.sql`, set `SUPABASE_URL`,
+  `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` and `SUBMITTER_HASH_SECRET`
+  in Vercel; `getTileAdapters()` leaves stub mode on its own once all three
+  Supabase vars are present.
+- **Doodle wall, Stage 2** — the admin moderation view over the
+  pre-moderation queue (Supabase Auth Google OAuth, hard allow-listed to
+  Nick's account) with approve/reject, plus the free daily keepalive cron
+  (ADR-0001).
+- **Keyboard navigation** for scene and games (carried over from the July
+  2026 audit — `IsoControls` is still pointer/touch only).

--- a/docs/redesign/architecture.md
+++ b/docs/redesign/architecture.md
@@ -33,23 +33,68 @@ No character controller / collision.
 
 ## Doodle wall backend (Supabase) — ADR-0001
 
-**Storage & data**
+Stage 1 (the visitor path) is **shipped** as a hexagonal slice: routes →
+domain service/ports → adapters. Stage 2 (admin moderation + keepalive) is
+not built, and the Supabase project is not yet provisioned — both routes run
+in **stub mode** against in-memory fakes until it is.
 
-- Supabase **Storage** bucket holds each tile's small PNG (~256×256).
-- Supabase **Postgres** `tiles` table: `id`, `image_path`, `status` (`pending | approved | rejected`), `created_at`, `submitter_hash` (for rate-limit), maybe `approved_at`. Bounded display = query most-recent N `approved`.
-- **RLS:** public can `insert` (status forced `pending`) and `select` only `approved`; only the admin (Nick's Google identity) can update status.
+**Layout (shipped)**
 
-**Endpoints (Next.js Route Handlers, `app/api/...`)**
+- **Routes** (`src/app/api/`) — thin HTTP adapters over the service:
+  - `POST /api/tiles` (`api/tiles/route.ts`) — body `{ image: <base64 PNG> }`
+    (zod, unknown keys stripped); same-site Origin check, raw-body ceiling,
+    in-memory burst guard (`api/tiles/rateLimit.ts`, 2/min per IP), then
+    `tileService.submitTile`. 201 `{ id, status: 'pending', createdAt }`.
+  - `GET /api/wall` (`api/wall/route.ts`) — the newest ≤48 approved tiles,
+    CDN-cacheable (`s-maxage=60`), already projected to the public `WallTile`
+    shape (`{ id, imageUrl, createdAt }` — no `imagePath`, no
+    `submitterHash`; the projection is applied at the domain boundary).
+- **Domain** (`src/lib/doodle-wall/`) — pure of HTTP and of Supabase:
+  `tileService.ts` (every acceptance rule: PNG signature + exact 256×256 via
+  `png.ts`, 128 KB byte cap, forced-`pending` status, durable daily cap of 10
+  per submitter hash counted through the repository), `ports.ts`
+  (`TileRepository`, `TileImageStore` — the latter with `remove()` as the
+  compensation path when the row insert fails after the upload), `types.ts`
+  (`Tile` + the public `WallTile` projection), `constants.ts` (the server
+  truths — re-exported by `three/game/doodleWallConfig.ts` so scene and
+  overlay can never drift from what the server accepts), `submitterHash.ts`
+  (HMAC-SHA256 of the IP under a server secret — no raw IPs at rest) and
+  `fakes.ts` (in-memory adapters plus a programmatic PNG builder seeding the
+  stub wall and test fixtures).
+- **Adapters** (`src/lib/supabase/`) — dormant until provisioning.
+  `tileAdapters.ts` is the single selection point (akin to `FORTUNE_STUB`):
+  with any of the three Supabase vars absent both routes use the fakes; a
+  **partially** set env in production throws rather than silently serving
+  fakes. `serverClient.ts` builds the service-role client (server-only —
+  only this folder may import `@supabase/supabase-js`);
+  `tileRepository.ts` / `tileImageStore.ts` implement the ports.
+- **Env** (`.env.schema`): `SUPABASE_URL`, `SUPABASE_ANON_KEY` (unused by
+  this slice — declared for Stage 2 admin auth, but still gates stub mode),
+  `SUPABASE_SERVICE_ROLE_KEY`, and `SUBMITTER_HASH_SECRET` (required once the
+  Supabase env is set; a fixed dev constant stands in for stub mode only).
 
-- `POST /api/tiles` — accepts a drawing, stores PNG + `pending` row; rate-limited per `submitter_hash`/IP.
-- `GET /api/wall` — returns the most-recent N approved tiles (cacheable).
+**Storage & data** (`supabase/migrations/20260714115029_doodle_wall.sql` —
+reviewed-only, applied at provisioning, never run in CI)
+
+- `public.tiles`: `id`, `image_path`, `status`
+  (`pending | approved | rejected`), `submitter_hash`, `created_at`,
+  `approved_at` (null until Stage 2 approves). Partial index for the wall
+  query; a `(submitter_hash, created_at)` index for the daily-cap count.
+- Storage bucket `tiles`: public read; content type (`image/png`) and the
+  128 KB cap pinned on the bucket as defence in depth.
+- **RLS is the backstop, not the write path:** anon may `select` approved
+  tiles only, and there is **no anon insert policy** — every write goes
+  through the service role (which bypasses RLS), so a leaked anon key can
+  neither read the queue nor flood it past `tileService`'s checks. The
+  service enforces every rule first.
+
+**Stage 2 (not built)**
+
 - `POST /api/admin/tiles/:id` — approve/reject; **auth-gated to Nick's Google account** (allow-list his email, not "any Google login").
-
-**Admin view:** a protected `/admin` route using Supabase Auth (Google OAuth) showing the pending queue with one-tap approve/reject (phone-friendly).
+- **Admin view:** a protected `/admin` route using Supabase Auth (Google OAuth) showing the pending queue with one-tap approve/reject (phone-friendly).
+- **Keepalive:** Supabase free projects pause after ~1 week idle → a free daily cron (GitHub Action or Vercel cron) pings the DB so the wall is never asleep.
 
 **No realtime** — new approved tiles appear on next load/poll.
-
-**Keepalive:** Supabase free projects pause after ~1 week idle → a free daily cron (GitHub Action or Vercel cron) pings the DB so the wall is never asleep.
 
 ## Quality tiers / profiles
 
@@ -68,13 +113,13 @@ Extend `useQualityTier` (`high|low|none`) → **Full** (high), **Lite** (low), *
 src/
   app/
     page.tsx                  # carnival home (Midway + DOM content)
-    blog/page.tsx             # blog index
-    blog/[slug]/page.tsx      # post (SSG, no canvas)
-    admin/page.tsx            # moderation queue (Supabase Google OAuth)
-    api/tiles/route.ts        # submit tile
-    api/wall/route.ts         # fetch approved wall
-    api/admin/tiles/[id]/route.ts  # approve/reject (auth)
-    rss.xml/route.ts          # RSS feed
+    blog/page.tsx             # blog index (future)
+    blog/[slug]/page.tsx      # post (SSG, no canvas) (future)
+    admin/page.tsx            # moderation queue (Supabase Google OAuth) (Stage 2, not built)
+    api/tiles/route.ts        # submit tile (shipped; rateLimit.ts alongside)
+    api/wall/route.ts         # fetch approved wall (shipped)
+    api/admin/tiles/[id]/route.ts  # approve/reject (auth) (Stage 2, not built)
+    rss.xml/route.ts          # RSS feed (future)
   components/                 # role-based folders (see Component conventions below)
     three/                    # canvas-side scene: Scene, MidwayCanvas, synty/ (Unity→three
                               #   translation layer), game/ + tickets/ (sims + configs),
@@ -85,14 +130,21 @@ src/
     nav/                      # global nav: SiteNav, MuteButton
     ui/                       # (reserved) shared primitives — none exist yet
     blog/                     # blog reading components (future)
-    doodle/                   # drawing UI (canvas), tile, wall (future)
+                              # (doodle wall UI has no folder of its own: the board is
+                              #   three/game/DoodleWall.tsx, the step-in overlay is
+                              #   overlays/DoodleWallHud.tsx — role-based, as above)
   content/
     cv.ts                     # home content (existing)
     blog/*.mdx                # blog posts
   lib/
     fonts/                    # next/font setup: local.ts (Montserrat, Open Sans),
                               #   google.ts (Rye, IM Fell — letterpress HUD faces)
-    supabase/                 # client/server helpers (future)
+    doodle-wall/              # doodle wall domain: tileService, ports, types,
+                              #   constants, png, submitterHash, fakes
+    supabase/                 # doodle wall adapters: tileAdapters (selection +
+                              #   stub gate), serverClient, tileRepository, tileImageStore
+supabase/
+  migrations/*.sql            # reviewed-only DDL, applied at provisioning (not in CI)
 public/
   models/synty/*.glb          # converted neutral Synty assets
   models/npcs/*.glb           # NPC rigs (character + baked animation)
@@ -129,4 +181,4 @@ three/`, with Overlay/HUD/CV meaning what `CONTEXT.md` defines. Placing a
 
 ## Degradation contract (ADR-0003)
 
-If WebGL is unavailable or `prefers-reduced-motion: reduce`: no canvas mounts; the page renders the full styled, readable DOM (header, all roles, projects, contact). The doodle wall still shows approved tiles as images; drawing may be hidden in reduced-motion. Nothing essential is lost.
+If WebGL is unavailable or `prefers-reduced-motion: reduce`: no canvas mounts; the page renders the full styled, readable DOM (header, all roles, projects, contact). The doodle wall stays fully usable: `StaticCv`'s `#doodle-wall` link opens the same `DoodleWallHud` overlay (wall view + drawing surface, tiles as plain `<img>`s) — the hash is routed through `stepIn()`, no canvas required. Nothing essential is lost.

--- a/docs/redesign/doodle-wall-handoff.md
+++ b/docs/redesign/doodle-wall-handoff.md
@@ -17,11 +17,14 @@
 
 Two stages, each its own PR:
 
-1. **Stage 1 — visitor path:** ✅ **code-complete at `c43bf60`**, close-out chain done
-   (glossary-guard → /code-review high → docs-scribe → this absorb). **Next: raise the
-   PR.** Real Supabase stays dormant until Nick provisions (§5 Needs Nick).
+1. **Stage 1 — visitor path:** ✅ **complete — [PR #65](https://github.com/derozn/iamnick.dev/pull/65)
+   is OPEN** (head `4860738`). Close-out chain done (glossary-guard → /code-review high →
+   docs-scribe → absorb), plus Nick's board-only revision (§5). **Blocked on Nick:** PR
+   review (real-GPU look pass + carny copy sign-off), then merge. Real Supabase stays
+   dormant until he provisions (§5 Needs Nick).
 2. **Stage 2 — moderation:** `/admin` queue (Supabase Auth, Google OAuth, **hard
    allow-list of Nick's account only**), approve/reject route, daily keepalive cron.
+   **Do not start** until Stage 1 merges and Nick supplies his Google identity.
 
 ## 1. Current state (verified 2026-07-14, post-close-out, `c43bf60`)
 
@@ -41,13 +44,16 @@ Two stages, each its own PR:
   bucket-level limits. `.env.schema`: 4 vars, all `@sensitive @optional`; absent env =
   stub mode, **partial Supabase env in production throws** (tripwire in the adapter
   factory).
-- **Scene** (`f06f27a`, `20ecc3c`, `bc376a7`): `three/game/doodleWallConfig.ts`
-  (three-free; re-exports server truths and `WallTile`; own tests) and
-  `three/game/DoodleWall.tsx` — stall + 6×4 tile-grid board at the end of the Midway
-  (past contact), board riding above the stall roofline, bulb string via `BulbGlow`,
-  fed by `GET /api/wall`. Attraction entry `doodle-wall` (section `game:doodle-wall`)
-  in `synty/attractions.ts`. Own bisection key `?off=doodle` (`?off=game` again means
-  only the game sims).
+- **Scene** (`f06f27a`, `20ecc3c`, `bc376a7`, revised `4860738`):
+  `three/game/doodleWallConfig.ts` (three-free; re-exports server truths and
+  `WallTile`; own tests) and `three/game/DoodleWall.tsx` — a **freestanding**
+  bulb-strung 6×4 tile-grid board on poles in the NE fence corner at three
+  **(17.5, 39)**, fed by `GET /api/wall`. **No stall prefab** — the Stall_03 first
+  placed at (12.5, 36.8) sat inside the big tree canopy there and read as "inside a
+  tent" (Nick). Attraction entry `doodle-wall` (section `game:doodle-wall`) in
+  `synty/attractions.ts`; `Attraction.prefab` is now optional (unconsumed metadata) and
+  absent for this entry. Own bisection key `?off=doodle` (`?off=game` again means only
+  the game sims).
 - **Overlay + store** (`c600659`, `c902fa5`): `overlays/DoodleWallHud.tsx` — step-in
   overlay showing the approved wall (`<img>` grid) plus the 512→256 drawing surface
   (palette / 3 brushes / undo 20 / clear) and submit. Store slice in `src/store/scene.ts`:
@@ -152,7 +158,12 @@ no-canvas tier; wall bound 48 / scene 24 (6×4), age-out = falling out of the qu
 and PNGs retained; 512→256 tile, server rejects wrong dimensions or >128KB; fixed
 near-black ground + ~6 neon inks, 3 brushes, undo 20, clear, no eraser/text; burst
 2/min/IP in-memory + durable daily cap 10 via `submitter_hash` = HMAC-SHA256(IP, env
-secret); Synty stall variant distinct from ball-toss with `BulbGlow` bulb string.
+secret).
+
+**Revised (Nick, 2026-07-14, after seeing the build):** the grill's "Synty stall +
+bulb-strung board" is superseded — **no stall prefab at all**. The doodle wall is the
+freestanding bulb-strung board alone, on its own poles (`4860738`). It is still a
+_stall_ in the glossary sense (a steppable game); it just has no Synty stall structure.
 
 **Backend-slice deviations (canon):** JSON `{ error }` bodies; no zod length cap on the
 base64 field (raw ceiling + service byte cap own size); fake-adapter seed PNGs generated
@@ -224,9 +235,10 @@ programmatically.
 - **Domain + routes + config:** ✅ covered by colocated unit tests against fakes.
 - **Scene/overlay headless:** recipe in `ball-toss-game-handoff.md` §6 (Playwright +
   swiftshader, `?debug=1` + `window.__sceneStore`; `?off=doodle` isolates the wall).
-  Builder screenshots predate the review fixes — a headless re-verify of the
-  `#doodle-wall` hash entry and the new error cards is **optional but recommended**
-  before the PR (behaviour changed since those shots).
+  ✅ Re-verified at `4860738`: fly-in frames the freestanding board (grid + bulbs +
+  fence behind) and the board reads from the travelling view past the big top
+  (scripts: `/tmp/shot/doodle-board.mjs`, `doodle-area.mjs` — uncommitted rig). Still
+  unexercised visually: the new error cards and the `#doodle-wall` hash entry.
 - **End-to-end (Supabase staging, after provisioning):** draw → submit → row `pending`
   and NOT on the wall → approve → tile appears on next `/api/wall` load.
   Non-allow-listed Google account denied `/admin` (Stage 2).
@@ -259,21 +271,27 @@ programmatically.
 5. ~~Overlay: drawing surface + submit flow + store slice~~ ✅ (`c600659`, `c902fa5`).
 6. ~~Close-out: glossary-guard → /code-review (high) → docs-scribe → absorb~~ ✅
    (`5a2df8d`, `c43bf60`; docs-scribe + this absorb 2026-07-14).
-7. **Raise the Stage 1 PR** (target `master`). Optional first: headless re-verify of
-   hash entry + error cards (§6).
-8. Swap in real Supabase behind the ports once Nick provisions (gate) + his real-GPU
-   look pass.
-9. Stage 2: admin + keepalive, same shape (brief from this doc; contracts in §2.1).
+7. ~~Raise the Stage 1 PR~~ ✅ **PR #65 open** (docs sync `b4bc279`; board-only
+   revision `4860738` pushed to it).
+8. **← YOU ARE HERE. Blocked on Nick:** PR #65 review (real-GPU look pass on the
+   freestanding board + carny copy sign-off) → merge → provisioning gate (§5).
+9. Stage 2: admin + keepalive, same shape (brief from this doc; contracts in §2.1;
+   needs Nick's Google identity for the allow-list before any code).
 
 ## 9. What just happened
 
-2026-07-14 (later) — **Stage 1 scene + overlay slice landed and the close-out chain
-ran.** Scene slice: `f06f27a` (config), `c600659` (store slice), `20ecc3c` (stall +
-board), `c902fa5` (step-in overlay), `bc376a7` (final placement — board rides the
-roofline at the Midway's end). Close-out: glossary-guard `5a2df8d` ('slot' reworded,
-**the carny** added to `CONTEXT.md`, HUD enumeration updated; one advisory parked —
-`resume-*` → `cv-*` sweep, §5); /code-review high `c43bf60` (12 confirmed findings
-fixed, §5; 8 verified cleanup findings deliberately parked, §5). Gate green at
-`c43bf60`: typecheck / lint / test:ci 120 / build. docs-scribe sync ran with this
-absorb. Next: the Stage 1 PR (§8 step 7), then the provisioning gate and Nick's
-real-GPU pass (Needs Nick).
+2026-07-14 (latest) — **PR #65 raised, then Nick's board-only revision landed on it.**
+After the close-out chain (`5a2df8d` glossary, `c43bf60` twelve review fixes,
+`b4bc279` docs sync) the Stage 1 PR went up. Nick then flagged the wall sitting "in
+the middle of a tent": the culprit was the big tree canopy (`SM_Env_Leaves_01` at
+three ≈(11.6, 35.4)) swallowing the stall placement at (12.5, 36.8). Fix `4860738`:
+stall prefab removed entirely (Nick's call — board only), the bulb-strung board now
+freestanding on poles at three **(17.5, 39)** in the NE fence corner,
+`Attraction.prefab` made optional. Verified by headless fly-in + travelling
+screenshots; gate green (120 tests). **Everything is now waiting on Nick** (§8 step 8):
+PR #65 review/merge, then provisioning, then Stage 2.
+
+For a NEW session picking this up: read `CONTEXT.md`, then this doc top to bottom —
+§2.1 has the frozen contracts, §5 the canon decisions + parked follow-ons, §8 the next
+action. The `carnival-context` agent (`.claude/agents/carnival-context.md`) briefs
+builders from this doc and absorbs outcomes back into it — keep that loop.

--- a/docs/redesign/doodle-wall-handoff.md
+++ b/docs/redesign/doodle-wall-handoff.md
@@ -1,0 +1,198 @@
+# Doodle Wall — Living Handoff
+
+> **Mission:** build the **doodle wall** — the communal stall at the end of the Midway where
+> any visitor draws a tile, it enters the pre-moderation queue, and once Nick approves it,
+> it joins a bounded grid of the most-recent approved tiles. Full-feature (view + draw) on
+> both Full and Lite. The site's first persistent backend (ADR-0001: Supabase).
+>
+> This is the **living** doc for the effort — maintained by the `carnival-context` agent
+> (`.claude/agents/carnival-context.md`). Builders are briefed from it; outcomes are folded
+> back in. Read `CONTEXT.md` first — its language is law.
+>
+> Branch: `feature/doodle-wall`. PRs target `master`.
+
+---
+
+## 0. TL;DR of what to do
+
+Two stages, each its own PR:
+
+1. **Stage 1 — visitor path:** Supabase schema (tiles + RLS + Storage), domain layer
+   (`src/lib/doodle-wall/`), thin API routes (`POST /api/tiles`, `GET /api/wall`), the
+   in-scene stall + approved-tile grid (`DoodleWall.tsx`), the drawing overlay
+   (`DoodleWallHud.tsx`), store slice, attraction registration.
+2. **Stage 2 — moderation:** `/admin` queue (Supabase Auth, Google OAuth, **hard
+   allow-list of Nick's account only**), approve/reject route, daily keepalive cron.
+
+**Before any feature code:** the `/grill-with-docs` session (§5) must close the open
+parameters. Its outcomes land in `doodleWallConfig.ts` and §5 of this doc.
+
+## 1. Current state (verified 2026-07-14)
+
+- **Nothing of the doodle wall exists yet.** No route, no component, no store slice, no
+  attraction entry. `src/app/api/` contains only `fortune/`; `src/lib/` is flat utilities
+  plus `fonts/`.
+- **Binding decisions already made:** ADR-0001 (Supabase; pre-moderation queue; bounded
+  recent-approved wall; no realtime; per-session/IP rate-limiting; keepalive cron; admin
+  hard allow-list). Reaffirmed by Nick 2026-07-14 over a Vercel-native alternative.
+- **The stall pattern to mirror** is ball-toss: config (`three/game/ballTossConfig.ts`,
+  three-free) + in-Canvas game (`three/game/BallTossGame.tsx`) + DOM HUD
+  (`overlays/BallTossHud.tsx`) + store summary slice (`src/store/scene.ts`) + attraction
+  entry (`three/synty/attractions.ts`). See `ball-toss-game-handoff.md` §2 for the
+  indicator → fly-in → `stepIn()` flow; it already works for `game:` sections.
+- **The API pattern to mirror** is the fortune route (`src/app/api/fortune/route.ts`):
+  Node runtime, zod validation, `rate-limiter-flexible` in-memory limiter, varlock-declared
+  env (`.env.schema`), keyless stub mode for local dev.
+- The site is live on Vercel; master is the deployed branch.
+
+## 2. Architecture (binding)
+
+**Loose hexagonal — Nick's rule: no mixing of concerns, no bloated files.**
+
+```
+src/app/api/*/route.ts        thin HTTP adapters: parse (zod) → rate-limit → call service → shape response
+src/lib/doodle-wall/          domain: tile types, tileService (submit rules, bounded wall
+                              query, moderation rules), ports (TileRepository, TileImageStore)
+src/lib/supabase/             adapter: server/service-role clients + port implementations.
+                              ONLY this folder imports supabase-js.
+```
+
+- Services are pure of HTTP and of Supabase; unit-test them against in-memory fakes.
+- One interface per dependency direction, no further ceremony.
+- Service-role key is server-only; never reaches the client bundle.
+- RLS is the backstop, not the only enforcement: public may insert (status forced
+  `pending`) and select `approved` only; status changes are admin-only.
+
+**Skills builders MUST consult:** `supabase` (+ `supabase-postgres-best-practices` for
+schema/query design) for any Supabase work; `security-best-practices` for any API surface;
+the relevant `r3f-*` skill for canvas work; `building-components` for the drawing overlay.
+
+## 3. Feature spec (v1)
+
+- **Wall (scenery):** a grid of the most-recent approved tiles rendered on the stall in the
+  scene — textured planes fed from `GET /api/wall`. Visible to everyone while travelling.
+- **Step-in (draw):** the stall's Play affordance steps in; a DOM overlay presents a square
+  drawing surface (`<canvas>`), palette/brush/undo/clear, and Submit. Works with touch and
+  pointer; full-feature on Full AND Lite (unlike ball-toss, no quality gate).
+- **Submit:** PNG posted to `POST /api/tiles` → Storage upload + `pending` row. The visitor
+  sees a "your tile is with the carny for approval" style confirmation — their tile does
+  NOT appear on the wall yet.
+- **Moderation (Stage 2):** Nick approves/rejects from `/admin` on his phone; approved
+  tiles appear on next wall load. No realtime.
+- **Degradation (ADR-0003):** no WebGL / reduced-motion → approved tiles render as plain
+  `<img>` elements; drawing may be hidden. Nothing essential lost.
+
+## 4. File map
+
+| Piece                              | Path                                                                             | Stage |
+| ---------------------------------- | -------------------------------------------------------------------------------- | ----- |
+| SQL migration (tiles, RLS, bucket) | `supabase/migrations/…`                                                          | 1     |
+| Domain: types, ports, service      | `src/lib/doodle-wall/`                                                           | 1     |
+| Supabase clients + adapters        | `src/lib/supabase/`                                                              | 1     |
+| Submit route (thin)                | `src/app/api/tiles/route.ts`                                                     | 1     |
+| Wall route (thin, cacheable)       | `src/app/api/wall/route.ts`                                                      | 1     |
+| Tuning config (three-free) + tests | `src/components/three/game/doodleWallConfig.ts`                                  | 1     |
+| In-scene stall + tile grid         | `src/components/three/game/DoodleWall.tsx`                                       | 1     |
+| Drawing overlay                    | `src/components/overlays/DoodleWallHud.tsx`                                      | 1     |
+| Store slice                        | `src/store/scene.ts` (extend)                                                    | 1     |
+| Attraction entry                   | `src/components/three/synty/attractions.ts` (extend)                             | 1     |
+| Env vars                           | `.env.schema` (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`) | 1     |
+| Admin queue page                   | `src/app/admin/page.tsx`                                                         | 2     |
+| Approve/reject route               | `src/app/api/admin/tiles/[id]/route.ts`                                          | 2     |
+| Keepalive route + cron             | `src/app/api/keepalive/route.ts` + Vercel cron                                   | 2     |
+
+## 5. Decisions
+
+**Made:**
+
+- Supabase backend — ADR-0001, reaffirmed by Nick 2026-07-14.
+- Staged delivery, visitor path first — Nick, 2026-07-14.
+- Loose hexagonal API architecture — Nick, 2026-07-14 (§2).
+- Skills mandate (supabase / security-best-practices) — Nick, 2026-07-14 (§2).
+- **Display surface** — in-scene tile grid as scenery; step-in opens a DOM overlay showing
+  BOTH the approved wall (`<img>` grid) and the drawing surface. The overlay is also the
+  wall's home on the no-canvas tier (linked from `StaticCv`), keeping the 3D grid purely
+  decorative per ADR-0003 — grill session, Nick, 2026-07-14.
+- **Wall bound + age-out** — `GET /api/wall` returns the newest 48 approved tiles; the
+  in-scene grid renders the newest 24 (fixed 6×4); the overlay shows all 48. Age-out =
+  falling out of the query; rows and PNGs are retained, not deleted — grill session, Nick,
+  2026-07-14.
+- **Tile size** — drawing canvas 512×512 internal, exported as 256×256 PNG; server rejects
+  wrong dimensions or >128KB — grill session, Nick, 2026-07-14.
+- **Drawing tools** — fixed near-black tile ground + ~6 neon inks drawn from the scene's
+  existing bulb/neon hues; 3 brush sizes; undo (20 steps); clear. No eraser, no text tool
+  — grill session, Nick, 2026-07-14.
+- **Rate limiting + submitter_hash** — burst guard 2 submissions/min per IP in-memory
+  (mirror `api/fortune/rateLimit.ts`); daily cap 10/day enforced durably by counting rows
+  with the same `submitter_hash` in the last 24h. `submitter_hash` = HMAC-SHA256(IP,
+  server secret from env) — stable for abuse tracing, no raw IP at rest — grill session,
+  Nick, 2026-07-14. (Adds `SUBMITTER_HASH_SECRET` to `.env.schema`.)
+- **Wall visual** — a Synty stall variant distinct from ball-toss's `Stall_02` (try
+  `Stall_01`/`Stall_03`) housing a large flat board with the 6×4 tile grid; practical
+  bulb string around the board via the existing `BulbGlow` system; thin emissive frame
+  line per tile. Exact placement/offsets iterated visually; final look judged on Nick's
+  Mac — grill session, Nick, 2026-07-14.
+
+**Open:**
+
+- Admin queue UX details (batch approve, preview size) — resolve at Stage 2 start.
+- Exact stall placement on the Midway (after contact, per CONTEXT.md order) — iterate
+  visually during the scene slice.
+
+**Needs Nick (human gates):**
+
+- Provision the Supabase project and set the three env secrets (local + Vercel) before
+  Stage 1 goes live. Until then everything runs against a stub/fake adapter.
+- Stage 2 admin allow-list uses Nick's actual Google identity — collect it at Stage 2
+  start; never widen to "any Google login" (ADR-0001).
+- Final look/feel judgement on his Mac (real GPU).
+
+## 6. How to verify
+
+- **Gate (every slice):** `pnpm typecheck && pnpm lint && pnpm test:ci && pnpm build`.
+- **Domain:** unit tests for `tileService` against in-memory fakes (pending-forced-on-
+  submit, bounded wall query, size cap). Config helpers in `doodleWallConfig.test.ts`.
+- **Routes:** handler tests — rate-limit rejects flooding, invalid payload 400s, wall
+  returns approved only.
+- **Scene:** headless Playwright + swiftshader screenshots (recipe and iso-camera maths in
+  `ball-toss-game-handoff.md` §6; drive state via `?debug=1` + `window.__sceneStore`).
+  Check the wall grid renders and the overlay opens on step-in, on Full and Lite.
+- **End-to-end (Supabase staging, after provisioning):** draw → submit → row is `pending`
+  and NOT on the wall → approve → tile appears on next `/api/wall` load. Non-allow-listed
+  Google account is denied `/admin`.
+- **Degradation:** WebGL off → tiles render as `<img>`.
+
+## 7. Gotchas (inherited — details in `ball-toss-game-handoff.md` §7)
+
+- R3F lint rules: mutate refs only in `useFrame`/handlers; per-frame sim state in refs,
+  only summaries in the store.
+- Low tier runs `frameloop='demand'` — call `invalidate()` while anything animates.
+- No EffectComposer/bloom additions; emissive + `BulbGlow` sprites only.
+- Spawned GLB props rendering black → `material.vertexColors = false`.
+- Never `rm -rf .next` while a dev server runs; clean prod build for verification.
+- No `@react-three/*` imports in the static bundle; overlays may import three-free config
+  modules only (`doodleWallConfig.ts` must stay three-free).
+- Tile PNGs are user content: treat as untrusted (validate server-side, cap dimensions and
+  bytes, re-encode or content-type-pin on serve; no SVG).
+- Commit messages end `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+## 8. Build order
+
+1. ~~Grill session closes §5 open decisions~~ ✅ done 2026-07-14; outcomes in §5.
+2. Domain layer + fake adapters + unit tests (no Supabase needed). Server truths (tile
+   dims, byte cap, wall/scene bounds, rate limits) live in `src/lib/doodle-wall/` and are
+   re-exported by `doodleWallConfig.ts` for scene/overlay use — one source, both sides
+   three-free.
+3. Routes (thin) against the fake adapter; stub mode akin to `FORTUNE_STUB`.
+4. Scene: attraction entry + stall + wall grid fed by `/api/wall` (stub data).
+5. Overlay: drawing surface + submit flow + store slice.
+6. Swap in real Supabase adapter behind the ports once Nick provisions (gate).
+7. Close-out: glossary-guard → /code-review (high) → docs-scribe → absorb here.
+8. Stage 2: admin + keepalive, same shape.
+
+## 9. What just happened
+
+2026-07-14 — Plan approved (`~/.claude/plans/i-want-to-do-effervescent-parasol.md`);
+`feature/doodle-wall` branched from a clean master (`9360f16`); `carnival-context` agent
+created; this doc seeded. Grill session then closed every open parameter (§5) and synced
+`open-questions.md`. Next: Stage 1, backend slice first (§8 step 2–3), then scene slice.

--- a/docs/redesign/doodle-wall-handoff.md
+++ b/docs/redesign/doodle-wall-handoff.md
@@ -24,14 +24,32 @@ Two stages, each its own PR:
 2. **Stage 2 — moderation:** `/admin` queue (Supabase Auth, Google OAuth, **hard
    allow-list of Nick's account only**), approve/reject route, daily keepalive cron.
 
-**Before any feature code:** the `/grill-with-docs` session (§5) must close the open
-parameters. Its outcomes land in `doodleWallConfig.ts` and §5 of this doc.
+Stage 1 progress: backend half ✅ done (contracts in §2.1); scene + overlay half is next
+(§8 steps 4–5). All tuning parameters were fixed in the 2026-07-14 grill session (§5).
 
-## 1. Current state (verified 2026-07-14)
+## 1. Current state (verified 2026-07-14, post-backend-slice)
 
-- **Nothing of the doodle wall exists yet.** No route, no component, no store slice, no
-  attraction entry. `src/app/api/` contains only `fortune/`; `src/lib/` is flat utilities
-  plus `fonts/`.
+- **Data + backend slice is DONE** (commits `58bf8ad`, `6d758dc`, `d28b50d`; gate green —
+  typecheck/lint/test:ci 111 tests/build, keyless):
+  - Domain layer `src/lib/doodle-wall/`: `types.ts`, `constants.ts` (server truths — see
+    §2.1), `ports.ts`, `png.ts` (hand-parsed PNG validator), `submitterHash.ts`,
+    `tileService.ts`, `fakes.ts` (in-memory adapters + programmatic PNG builder + 24
+    seeded approved tiles), colocated tests.
+  - Thin routes: `src/app/api/tiles/route.ts` (POST, + sibling `rateLimit.ts`, burst
+    2/min/IP) and `src/app/api/wall/route.ts` (GET), mirroring fortune conventions.
+  - Supabase adapters (dormant until provisioning): `src/lib/supabase/` —
+    `serverClient.ts`, `tileRepository.ts`, `tileImageStore.ts`, `tileAdapters.ts`
+    (selection factory + `resetTileAdapters()` + `DEV_SUBMITTER_HASH_SECRET`).
+    supabase-js confined to that folder (grep-verified). Dep: `@supabase/supabase-js
+^2.110.2`.
+  - Migration `supabase/migrations/20260714115029_doodle_wall.sql`: tiles table, partial
+    index (`created_at desc where status='approved'`), `(submitter_hash, created_at)`
+    index, RLS anon insert-pending-only / select-approved-only, `tiles` bucket
+    public-read with 128KB + image/png limits at bucket level.
+  - `.env.schema`: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`,
+    `SUBMITTER_HASH_SECRET` — all `@sensitive @optional`; absent env = stub mode.
+- **Nothing scene/overlay-side exists yet.** No `doodleWallConfig.ts`, no
+  `DoodleWall.tsx`, no `DoodleWallHud.tsx`, no store slice, no attraction entry.
 - **Binding decisions already made:** ADR-0001 (Supabase; pre-moderation queue; bounded
   recent-approved wall; no realtime; per-session/IP rate-limiting; keepalive cron; admin
   hard allow-list). Reaffirmed by Nick 2026-07-14 over a Vercel-native alternative.
@@ -67,6 +85,23 @@ src/lib/supabase/             adapter: server/service-role clients + port implem
 schema/query design) for any Supabase work; `security-best-practices` for any API surface;
 the relevant `r3f-*` skill for canvas work; `building-components` for the drawing overlay.
 
+### 2.1 Landed contracts (next slices build against these — do not renegotiate)
+
+**Server truths** (`src/lib/doodle-wall/constants.ts` — re-export from
+`doodleWallConfig.ts`, never redefine): `STORED_TILE_SIZE` 256, `DRAWING_CANVAS_SIZE`
+512, `TILE_MAX_BYTES` 131072, `WALL_TILE_COUNT` 48, `SCENE_TILE_COUNT` 24,
+`SUBMIT_BURST_PER_MINUTE` 2, `SUBMIT_DAILY_CAP` 10.
+
+**`POST /api/tiles`** — body `{ "image": "<base64 PNG, no data: prefix>" }`, raw request
+ceiling 204800 bytes. 201 → `{ id, status: 'pending', createdAt }` (ISO). Errors as
+`{ error }` JSON: 400 `invalid-request` | `invalid-image`, 413 `too-large`, 429
+`rate-limited` (burst AND daily cap share this token), 403 `bad-origin`.
+
+**`GET /api/wall`** — 200 → `{ tiles: [{ id, imageUrl, createdAt }] }`, newest first,
+≤48, `Cache-Control: public, s-maxage=60, stale-while-revalidate=300`. In stub mode
+`imageUrl` is a `data:image/png;base64,` URI; with Supabase it is a Storage public URL —
+**consumers must handle both**.
+
 ## 3. Feature spec (v1)
 
 - **Wall (scenery):** a grid of the most-recent approved tiles rendered on the stall in the
@@ -84,22 +119,22 @@ the relevant `r3f-*` skill for canvas work; `building-components` for the drawin
 
 ## 4. File map
 
-| Piece                              | Path                                                                             | Stage |
-| ---------------------------------- | -------------------------------------------------------------------------------- | ----- |
-| SQL migration (tiles, RLS, bucket) | `supabase/migrations/…`                                                          | 1     |
-| Domain: types, ports, service      | `src/lib/doodle-wall/`                                                           | 1     |
-| Supabase clients + adapters        | `src/lib/supabase/`                                                              | 1     |
-| Submit route (thin)                | `src/app/api/tiles/route.ts`                                                     | 1     |
-| Wall route (thin, cacheable)       | `src/app/api/wall/route.ts`                                                      | 1     |
-| Tuning config (three-free) + tests | `src/components/three/game/doodleWallConfig.ts`                                  | 1     |
-| In-scene stall + tile grid         | `src/components/three/game/DoodleWall.tsx`                                       | 1     |
-| Drawing overlay                    | `src/components/overlays/DoodleWallHud.tsx`                                      | 1     |
-| Store slice                        | `src/store/scene.ts` (extend)                                                    | 1     |
-| Attraction entry                   | `src/components/three/synty/attractions.ts` (extend)                             | 1     |
-| Env vars                           | `.env.schema` (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`) | 1     |
-| Admin queue page                   | `src/app/admin/page.tsx`                                                         | 2     |
-| Approve/reject route               | `src/app/api/admin/tiles/[id]/route.ts`                                          | 2     |
-| Keepalive route + cron             | `src/app/api/keepalive/route.ts` + Vercel cron                                   | 2     |
+| Piece                              | Path                                                                          | Stage | Status  |
+| ---------------------------------- | ----------------------------------------------------------------------------- | ----- | ------- |
+| SQL migration (tiles, RLS, bucket) | `supabase/migrations/20260714115029_doodle_wall.sql`                          | 1     | ✅ done |
+| Domain: types, ports, service      | `src/lib/doodle-wall/`                                                        | 1     | ✅ done |
+| Supabase clients + adapters        | `src/lib/supabase/` (dormant until provisioning)                              | 1     | ✅ done |
+| Submit route (thin) + rate limiter | `src/app/api/tiles/route.ts` + `rateLimit.ts`                                 | 1     | ✅ done |
+| Wall route (thin, cacheable)       | `src/app/api/wall/route.ts`                                                   | 1     | ✅ done |
+| Env vars (4, all optional)         | `.env.schema` (SUPABASE_URL/ANON_KEY/SERVICE_ROLE_KEY, SUBMITTER_HASH_SECRET) | 1     | ✅ done |
+| Tuning config (three-free) + tests | `src/components/three/game/doodleWallConfig.ts`                               | 1     | next    |
+| In-scene stall + tile grid         | `src/components/three/game/DoodleWall.tsx`                                    | 1     | next    |
+| Drawing overlay                    | `src/components/overlays/DoodleWallHud.tsx`                                   | 1     | next    |
+| Store slice                        | `src/store/scene.ts` (extend)                                                 | 1     | next    |
+| Attraction entry                   | `src/components/three/synty/attractions.ts` (extend)                          | 1     | next    |
+| Admin queue page                   | `src/app/admin/page.tsx`                                                      | 2     | —       |
+| Approve/reject route               | `src/app/api/admin/tiles/[id]/route.ts`                                       | 2     | —       |
+| Keepalive route + cron             | `src/app/api/keepalive/route.ts` + Vercel cron                                | 2     | —       |
 
 ## 5. Decisions
 
@@ -133,6 +168,13 @@ the relevant `r3f-*` skill for canvas work; `building-components` for the drawin
   line per tile. Exact placement/offsets iterated visually; final look judged on Nick's
   Mac — grill session, Nick, 2026-07-14.
 
+**Backend-slice deviations (accepted, now canon):**
+
+- Routes return JSON `{ error }` bodies rather than fortune's plain text.
+- No zod length cap on the base64 field — the raw request ceiling (204800B) + the
+  service byte cap own size enforcement.
+- Fake-adapter seed PNGs are generated programmatically, not embedded fixtures.
+
 **Open:**
 
 - Admin queue UX details (batch approve, preview size) — resolve at Stage 2 start.
@@ -141,19 +183,21 @@ the relevant `r3f-*` skill for canvas work; `building-components` for the drawin
 
 **Needs Nick (human gates):**
 
-- Provision the Supabase project and set the three env secrets (local + Vercel) before
-  Stage 1 goes live. Until then everything runs against a stub/fake adapter.
+- **Provisioning gate (before real Supabase goes live):** create the Supabase project →
+  run the migration (it also creates the `tiles` bucket) → set the four env vars (local
+  - Vercel). Until then everything runs in stub mode. Note: Supabase env present but
+    `SUBMITTER_HASH_SECRET` missing throws at request time — by design.
 - Stage 2 admin allow-list uses Nick's actual Google identity — collect it at Stage 2
   start; never widen to "any Google login" (ADR-0001).
 - Final look/feel judgement on his Mac (real GPU).
 
 ## 6. How to verify
 
-- **Gate (every slice):** `pnpm typecheck && pnpm lint && pnpm test:ci && pnpm build`.
-- **Domain:** unit tests for `tileService` against in-memory fakes (pending-forced-on-
-  submit, bounded wall query, size cap). Config helpers in `doodleWallConfig.test.ts`.
-- **Routes:** handler tests — rate-limit rejects flooding, invalid payload 400s, wall
-  returns approved only.
+- **Gate (every slice):** `pnpm typecheck && pnpm lint && pnpm test:ci && pnpm build`
+  (currently 111 tests, keyless).
+- **Domain + routes:** ✅ covered — `tileService`/`png`/`submitterHash` unit tests
+  against fakes; route handler tests (rate-limit, 400s, approved-only wall). Config
+  helpers go in `doodleWallConfig.test.ts` (scene slice).
 - **Scene:** headless Playwright + swiftshader screenshots (recipe and iso-camera maths in
   `ball-toss-game-handoff.md` §6; drive state via `?debug=1` + `window.__sceneStore`).
   Check the wall grid renders and the overlay opens on step-in, on Full and Lite.
@@ -174,16 +218,21 @@ the relevant `r3f-*` skill for canvas work; `building-components` for the drawin
   modules only (`doodleWallConfig.ts` must stay three-free).
 - Tile PNGs are user content: treat as untrusted (validate server-side, cap dimensions and
   bytes, re-encode or content-type-pin on serve; no SVG).
+- `pnpm knip` flags `DRAWING_CANVAS_SIZE`/`SCENE_TILE_COUNT` until the scene/overlay
+  slice consumes them — expected, resolves itself.
+- `GET /api/wall` `imageUrl` is a data URI in stub mode, an https Storage URL with
+  Supabase — scene textures and overlay `<img>`s must handle both.
+- Nick's dev server usually holds port 3000 — smoke servers go on a spare port (backend
+  slice used 3100).
 - Commit messages end `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
 
 ## 8. Build order
 
 1. ~~Grill session closes §5 open decisions~~ ✅ done 2026-07-14; outcomes in §5.
-2. Domain layer + fake adapters + unit tests (no Supabase needed). Server truths (tile
-   dims, byte cap, wall/scene bounds, rate limits) live in `src/lib/doodle-wall/` and are
-   re-exported by `doodleWallConfig.ts` for scene/overlay use — one source, both sides
-   three-free.
-3. Routes (thin) against the fake adapter; stub mode akin to `FORTUNE_STUB`.
+2. ~~Domain layer + fake adapters + unit tests~~ ✅ done (`58bf8ad`); server truths in
+   `src/lib/doodle-wall/constants.ts`, to be re-exported by `doodleWallConfig.ts`.
+3. ~~Routes (thin) against the fake adapter; stub mode; Supabase adapters dormant~~ ✅
+   done (`6d758dc`); contracts in §2.1.
 4. Scene: attraction entry + stall + wall grid fed by `/api/wall` (stub data).
 5. Overlay: drawing surface + submit flow + store slice.
 6. Swap in real Supabase adapter behind the ports once Nick provisions (gate).
@@ -192,7 +241,10 @@ the relevant `r3f-*` skill for canvas work; `building-components` for the drawin
 
 ## 9. What just happened
 
-2026-07-14 — Plan approved (`~/.claude/plans/i-want-to-do-effervescent-parasol.md`);
-`feature/doodle-wall` branched from a clean master (`9360f16`); `carnival-context` agent
-created; this doc seeded. Grill session then closed every open parameter (§5) and synced
-`open-questions.md`. Next: Stage 1, backend slice first (§8 step 2–3), then scene slice.
+2026-07-14 — **Stage 1 data + backend slice landed** (`58bf8ad` domain layer, `6d758dc`
+routes/adapters/migration/env, `d28b50d` comment reword). Gate green (111 tests,
+keyless); supabase-js confinement grep-verified; smoke-tested on port 3100. Route
+contracts and server truths recorded in §2.1; accepted deviations in §5. Earlier the
+same day: branch cut from `9360f16`, `carnival-context` agent created, doc seeded, grill
+session closed all open parameters. Next: the scene + overlay slice (§8 steps 4–5), then
+the Supabase provisioning gate (Needs Nick).

--- a/docs/redesign/doodle-wall-handoff.md
+++ b/docs/redesign/doodle-wall-handoff.md
@@ -17,51 +17,51 @@
 
 Two stages, each its own PR:
 
-1. **Stage 1 — visitor path:** Supabase schema (tiles + RLS + Storage), domain layer
-   (`src/lib/doodle-wall/`), thin API routes (`POST /api/tiles`, `GET /api/wall`), the
-   in-scene stall + approved-tile grid (`DoodleWall.tsx`), the drawing overlay
-   (`DoodleWallHud.tsx`), store slice, attraction registration.
+1. **Stage 1 — visitor path:** ✅ **code-complete at `c43bf60`**, close-out chain done
+   (glossary-guard → /code-review high → docs-scribe → this absorb). **Next: raise the
+   PR.** Real Supabase stays dormant until Nick provisions (§5 Needs Nick).
 2. **Stage 2 — moderation:** `/admin` queue (Supabase Auth, Google OAuth, **hard
    allow-list of Nick's account only**), approve/reject route, daily keepalive cron.
 
-Stage 1 progress: backend half ✅ done (contracts in §2.1); scene + overlay half is next
-(§8 steps 4–5). All tuning parameters were fixed in the 2026-07-14 grill session (§5).
+## 1. Current state (verified 2026-07-14, post-close-out, `c43bf60`)
 
-## 1. Current state (verified 2026-07-14, post-backend-slice)
+**Stage 1 is built end to end.** Gate green at `c43bf60`: typecheck / lint / test:ci
+(120 tests, keyless) / build.
 
-- **Data + backend slice is DONE** (commits `58bf8ad`, `6d758dc`, `d28b50d`; gate green —
-  typecheck/lint/test:ci 111 tests/build, keyless):
-  - Domain layer `src/lib/doodle-wall/`: `types.ts`, `constants.ts` (server truths — see
-    §2.1), `ports.ts`, `png.ts` (hand-parsed PNG validator), `submitterHash.ts`,
-    `tileService.ts`, `fakes.ts` (in-memory adapters + programmatic PNG builder + 24
-    seeded approved tiles), colocated tests.
-  - Thin routes: `src/app/api/tiles/route.ts` (POST, + sibling `rateLimit.ts`, burst
-    2/min/IP) and `src/app/api/wall/route.ts` (GET), mirroring fortune conventions.
-  - Supabase adapters (dormant until provisioning): `src/lib/supabase/` —
-    `serverClient.ts`, `tileRepository.ts`, `tileImageStore.ts`, `tileAdapters.ts`
-    (selection factory + `resetTileAdapters()` + `DEV_SUBMITTER_HASH_SECRET`).
-    supabase-js confined to that folder (grep-verified). Dep: `@supabase/supabase-js
-^2.110.2`.
-  - Migration `supabase/migrations/20260714115029_doodle_wall.sql`: tiles table, partial
-    index (`created_at desc where status='approved'`), `(submitter_hash, created_at)`
-    index, RLS anon insert-pending-only / select-approved-only, `tiles` bucket
-    public-read with 128KB + image/png limits at bucket level.
-  - `.env.schema`: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`,
-    `SUBMITTER_HASH_SECRET` — all `@sensitive @optional`; absent env = stub mode.
-- **Nothing scene/overlay-side exists yet.** No `doodleWallConfig.ts`, no
-  `DoodleWall.tsx`, no `DoodleWallHud.tsx`, no store slice, no attraction entry.
-- **Binding decisions already made:** ADR-0001 (Supabase; pre-moderation queue; bounded
-  recent-approved wall; no realtime; per-session/IP rate-limiting; keepalive cron; admin
-  hard allow-list). Reaffirmed by Nick 2026-07-14 over a Vercel-native alternative.
-- **The stall pattern to mirror** is ball-toss: config (`three/game/ballTossConfig.ts`,
-  three-free) + in-Canvas game (`three/game/BallTossGame.tsx`) + DOM HUD
-  (`overlays/BallTossHud.tsx`) + store summary slice (`src/store/scene.ts`) + attraction
-  entry (`three/synty/attractions.ts`). See `ball-toss-game-handoff.md` §2 for the
-  indicator → fly-in → `stepIn()` flow; it already works for `game:` sections.
-- **The API pattern to mirror** is the fortune route (`src/app/api/fortune/route.ts`):
-  Node runtime, zod validation, `rate-limiter-flexible` in-memory limiter, varlock-declared
-  env (`.env.schema`), keyless stub mode for local dev.
-- The site is live on Vercel; master is the deployed branch.
+- **Backend** (`58bf8ad`, `6d758dc`): domain layer `src/lib/doodle-wall/` (`types.ts` —
+  now also home of the public `WallTile` shape — `constants.ts`, `ports.ts`, `png.ts`,
+  `submitterHash.ts`, `tileService.ts`, `fakes.ts`, colocated tests); thin routes
+  `src/app/api/tiles/route.ts` (+ sibling `rateLimit.ts`, burst 2/min/IP) and
+  `src/app/api/wall/route.ts`; Supabase adapters in `src/lib/supabase/` (dormant until
+  provisioning; supabase-js confined there, grep-verified; `TileImageStore` now has
+  `remove()` for insert-failure compensation). Migration
+  `supabase/migrations/20260714115029_doodle_wall.sql`: tiles table + indexes, RLS
+  **select-approved-only — the anon INSERT policy was dropped** (every legitimate write
+  goes through the service role), `tiles` bucket public-read with 128KB + image/png
+  bucket-level limits. `.env.schema`: 4 vars, all `@sensitive @optional`; absent env =
+  stub mode, **partial Supabase env in production throws** (tripwire in the adapter
+  factory).
+- **Scene** (`f06f27a`, `20ecc3c`, `bc376a7`): `three/game/doodleWallConfig.ts`
+  (three-free; re-exports server truths and `WallTile`; own tests) and
+  `three/game/DoodleWall.tsx` — stall + 6×4 tile-grid board at the end of the Midway
+  (past contact), board riding above the stall roofline, bulb string via `BulbGlow`,
+  fed by `GET /api/wall`. Attraction entry `doodle-wall` (section `game:doodle-wall`)
+  in `synty/attractions.ts`. Own bisection key `?off=doodle` (`?off=game` again means
+  only the game sims).
+- **Overlay + store** (`c600659`, `c902fa5`): `overlays/DoodleWallHud.tsx` — step-in
+  overlay showing the approved wall (`<img>` grid) plus the 512→256 drawing surface
+  (palette / 3 brushes / undo 20 / clear) and submit. Store slice in `src/store/scene.ts`:
+  `doodleWallPhase` (`intro | drawing | submitting | submitted | error`) +
+  `setDoodleWallPhase`; `stepIn('doodle-wall')` resets the phase atomically.
+  `#doodle-wall` hash-open routes through `stepIn()` so mode-keyed chrome (burger,
+  ticket tally) yields correctly; `StaticCv` links to a server-rendered
+  `id="doodle-wall"` target for the no-canvas tier.
+- **Close-out chain done:** glossary-guard (`5a2df8d` — 'slot' comments reworded,
+  **the carny** added to `CONTEXT.md`, HUD enumeration updated) and /code-review high
+  (`c43bf60` — 12 confirmed findings fixed, see §5). docs-scribe sync ran alongside
+  this absorb. **PR is the next step.**
+- Real Supabase is untested end to end — everything so far is stub mode + fakes. The
+  provisioning gate (§5 Needs Nick) blocks the live swap, not the PR.
 
 ## 2. Architecture (binding)
 
@@ -69,8 +69,9 @@ Stage 1 progress: backend half ✅ done (contracts in §2.1); scene + overlay ha
 
 ```
 src/app/api/*/route.ts        thin HTTP adapters: parse (zod) → rate-limit → call service → shape response
-src/lib/doodle-wall/          domain: tile types, tileService (submit rules, bounded wall
-                              query, moderation rules), ports (TileRepository, TileImageStore)
+src/lib/doodle-wall/          domain: tile types (incl. public WallTile), tileService (submit
+                              rules, bounded wall query, moderation rules), ports
+                              (TileRepository, TileImageStore)
 src/lib/supabase/             adapter: server/service-role clients + port implementations.
                               ONLY this folder imports supabase-js.
 ```
@@ -78,44 +79,50 @@ src/lib/supabase/             adapter: server/service-role clients + port implem
 - Services are pure of HTTP and of Supabase; unit-test them against in-memory fakes.
 - One interface per dependency direction, no further ceremony.
 - Service-role key is server-only; never reaches the client bundle.
-- RLS is the backstop, not the only enforcement: public may insert (status forced
-  `pending`) and select `approved` only; status changes are admin-only.
+- RLS is the backstop, not the only enforcement: anon may **select approved only**;
+  all writes (insert as `pending`, status changes) go through the service role.
 
 **Skills builders MUST consult:** `supabase` (+ `supabase-postgres-best-practices` for
 schema/query design) for any Supabase work; `security-best-practices` for any API surface;
-the relevant `r3f-*` skill for canvas work; `building-components` for the drawing overlay.
+the relevant `r3f-*` skill for canvas work; `building-components` for overlay work.
 
-### 2.1 Landed contracts (next slices build against these — do not renegotiate)
+### 2.1 Landed contracts (Stage 2 builds against these — do not renegotiate)
 
-**Server truths** (`src/lib/doodle-wall/constants.ts` — re-export from
-`doodleWallConfig.ts`, never redefine): `STORED_TILE_SIZE` 256, `DRAWING_CANVAS_SIZE`
+**Server truths** (`src/lib/doodle-wall/constants.ts` — re-exported by
+`doodleWallConfig.ts`, never redefined): `STORED_TILE_SIZE` 256, `DRAWING_CANVAS_SIZE`
 512, `TILE_MAX_BYTES` 131072, `WALL_TILE_COUNT` 48, `SCENE_TILE_COUNT` 24,
 `SUBMIT_BURST_PER_MINUTE` 2, `SUBMIT_DAILY_CAP` 10.
 
 **`POST /api/tiles`** — body `{ "image": "<base64 PNG, no data: prefix>" }`, raw request
-ceiling 204800 bytes. 201 → `{ id, status: 'pending', createdAt }` (ISO). Errors as
-`{ error }` JSON: 400 `invalid-request` | `invalid-image`, 413 `too-large`, 429
+ceiling 204800 bytes, byte-accurate (`Buffer.byteLength`) with a Content-Length
+pre-check before buffering. 201 → `{ id, status: 'pending', createdAt }` (ISO). Errors
+as `{ error }` JSON: 400 `invalid-request` | `invalid-image`, 413 `too-large`, 429
 `rate-limited` (burst AND daily cap share this token), 403 `bad-origin`.
 
-**`GET /api/wall`** — 200 → `{ tiles: [{ id, imageUrl, createdAt }] }`, newest first,
-≤48, `Cache-Control: public, s-maxage=60, stale-while-revalidate=300`. In stub mode
-`imageUrl` is a `data:image/png;base64,` URI; with Supabase it is a Storage public URL —
-**consumers must handle both**.
+**`GET /api/wall`** — 200 → `{ tiles: WallTile[] }` where `WallTile` =
+`{ id, imageUrl, createdAt }` (`src/lib/doodle-wall/types.ts` — the domain's
+`getWall()` projects to this public shape; `submitterHash`/`imagePath` never cross the
+boundary). Newest first, ≤48, `Cache-Control: public, s-maxage=60,
+stale-while-revalidate=300`. In stub mode `imageUrl` is a `data:image/png;base64,` URI;
+with Supabase it is a Storage public URL — **consumers must handle both**.
 
 ## 3. Feature spec (v1)
 
-- **Wall (scenery):** a grid of the most-recent approved tiles rendered on the stall in the
-  scene — textured planes fed from `GET /api/wall`. Visible to everyone while travelling.
-- **Step-in (draw):** the stall's Play affordance steps in; a DOM overlay presents a square
-  drawing surface (`<canvas>`), palette/brush/undo/clear, and Submit. Works with touch and
-  pointer; full-feature on Full AND Lite (unlike ball-toss, no quality gate).
-- **Submit:** PNG posted to `POST /api/tiles` → Storage upload + `pending` row. The visitor
-  sees a "your tile is with the carny for approval" style confirmation — their tile does
-  NOT appear on the wall yet.
+- **Wall (scenery):** a 6×4 grid of the newest 24 approved tiles on the stall's board in
+  the scene, fed from `GET /api/wall`. Visible to everyone while travelling.
+- **Step-in (draw):** the stall's Play affordance (or the `#doodle-wall` hash, routed
+  through `stepIn()`) opens the overlay: the full 48-tile approved wall as an `<img>`
+  grid plus a square drawing surface, palette/brush/undo/clear, Submit. Touch and
+  pointer; full-feature on Full AND Lite (no quality gate).
+- **Submit:** PNG posted to `POST /api/tiles` → Storage upload + `pending` row. The
+  visitor sees a "your tile is with the carny" confirmation — the tile does NOT appear
+  on the wall yet. Deterministic rejections (too-large, 400/403) get their own error
+  cards, distinct from transient failures with Try again.
 - **Moderation (Stage 2):** Nick approves/rejects from `/admin` on his phone; approved
   tiles appear on next wall load. No realtime.
-- **Degradation (ADR-0003):** no WebGL / reduced-motion → approved tiles render as plain
-  `<img>` elements; drawing may be hidden. Nothing essential lost.
+- **Degradation (ADR-0003):** no WebGL / reduced-motion → `StaticCv` links to the
+  overlay via `#doodle-wall`; approved tiles render as plain `<img>` elements. Nothing
+  essential lost.
 
 ## 4. File map
 
@@ -127,124 +134,146 @@ ceiling 204800 bytes. 201 → `{ id, status: 'pending', createdAt }` (ISO). Erro
 | Submit route (thin) + rate limiter | `src/app/api/tiles/route.ts` + `rateLimit.ts`                                 | 1     | ✅ done |
 | Wall route (thin, cacheable)       | `src/app/api/wall/route.ts`                                                   | 1     | ✅ done |
 | Env vars (4, all optional)         | `.env.schema` (SUPABASE_URL/ANON_KEY/SERVICE_ROLE_KEY, SUBMITTER_HASH_SECRET) | 1     | ✅ done |
-| Tuning config (three-free) + tests | `src/components/three/game/doodleWallConfig.ts`                               | 1     | next    |
-| In-scene stall + tile grid         | `src/components/three/game/DoodleWall.tsx`                                    | 1     | next    |
-| Drawing overlay                    | `src/components/overlays/DoodleWallHud.tsx`                                   | 1     | next    |
-| Store slice                        | `src/store/scene.ts` (extend)                                                 | 1     | next    |
-| Attraction entry                   | `src/components/three/synty/attractions.ts` (extend)                          | 1     | next    |
+| Tuning config (three-free) + tests | `src/components/three/game/doodleWallConfig.ts`                               | 1     | ✅ done |
+| In-scene stall + tile grid         | `src/components/three/game/DoodleWall.tsx`                                    | 1     | ✅ done |
+| Drawing overlay                    | `src/components/overlays/DoodleWallHud.tsx`                                   | 1     | ✅ done |
+| Store slice                        | `src/store/scene.ts` (`doodleWallPhase`)                                      | 1     | ✅ done |
+| Attraction entry                   | `src/components/three/synty/attractions.ts` (`doodle-wall`)                   | 1     | ✅ done |
 | Admin queue page                   | `src/app/admin/page.tsx`                                                      | 2     | —       |
 | Approve/reject route               | `src/app/api/admin/tiles/[id]/route.ts`                                       | 2     | —       |
 | Keepalive route + cron             | `src/app/api/keepalive/route.ts` + Vercel cron                                | 2     | —       |
 
 ## 5. Decisions
 
-**Made:**
+**Made (grill session, Nick, 2026-07-14 — unchanged):** Supabase backend (ADR-0001,
+reaffirmed); staged delivery, visitor path first; loose hexagonal architecture (§2);
+skills mandate (§2); overlay shows wall + drawing surface and is the wall's home on the
+no-canvas tier; wall bound 48 / scene 24 (6×4), age-out = falling out of the query, rows
+and PNGs retained; 512→256 tile, server rejects wrong dimensions or >128KB; fixed
+near-black ground + ~6 neon inks, 3 brushes, undo 20, clear, no eraser/text; burst
+2/min/IP in-memory + durable daily cap 10 via `submitter_hash` = HMAC-SHA256(IP, env
+secret); Synty stall variant distinct from ball-toss with `BulbGlow` bulb string.
 
-- Supabase backend — ADR-0001, reaffirmed by Nick 2026-07-14.
-- Staged delivery, visitor path first — Nick, 2026-07-14.
-- Loose hexagonal API architecture — Nick, 2026-07-14 (§2).
-- Skills mandate (supabase / security-best-practices) — Nick, 2026-07-14 (§2).
-- **Display surface** — in-scene tile grid as scenery; step-in opens a DOM overlay showing
-  BOTH the approved wall (`<img>` grid) and the drawing surface. The overlay is also the
-  wall's home on the no-canvas tier (linked from `StaticCv`), keeping the 3D grid purely
-  decorative per ADR-0003 — grill session, Nick, 2026-07-14.
-- **Wall bound + age-out** — `GET /api/wall` returns the newest 48 approved tiles; the
-  in-scene grid renders the newest 24 (fixed 6×4); the overlay shows all 48. Age-out =
-  falling out of the query; rows and PNGs are retained, not deleted — grill session, Nick,
-  2026-07-14.
-- **Tile size** — drawing canvas 512×512 internal, exported as 256×256 PNG; server rejects
-  wrong dimensions or >128KB — grill session, Nick, 2026-07-14.
-- **Drawing tools** — fixed near-black tile ground + ~6 neon inks drawn from the scene's
-  existing bulb/neon hues; 3 brush sizes; undo (20 steps); clear. No eraser, no text tool
-  — grill session, Nick, 2026-07-14.
-- **Rate limiting + submitter_hash** — burst guard 2 submissions/min per IP in-memory
-  (mirror `api/fortune/rateLimit.ts`); daily cap 10/day enforced durably by counting rows
-  with the same `submitter_hash` in the last 24h. `submitter_hash` = HMAC-SHA256(IP,
-  server secret from env) — stable for abuse tracing, no raw IP at rest — grill session,
-  Nick, 2026-07-14. (Adds `SUBMITTER_HASH_SECRET` to `.env.schema`.)
-- **Wall visual** — a Synty stall variant distinct from ball-toss's `Stall_02` (try
-  `Stall_01`/`Stall_03`) housing a large flat board with the 6×4 tile grid; practical
-  bulb string around the board via the existing `BulbGlow` system; thin emissive frame
-  line per tile. Exact placement/offsets iterated visually; final look judged on Nick's
-  Mac — grill session, Nick, 2026-07-14.
+**Backend-slice deviations (canon):** JSON `{ error }` bodies; no zod length cap on the
+base64 field (raw ceiling + service byte cap own size); fake-adapter seed PNGs generated
+programmatically.
 
-**Backend-slice deviations (accepted, now canon):**
+**Close-out fixes (code review `c43bf60`, now canon):**
 
-- Routes return JSON `{ error }` bodies rather than fortune's plain text.
-- No zod length cap on the base64 field — the raw request ceiling (204800B) + the
-  service byte cap own size enforcement.
-- Fake-adapter seed PNGs are generated programmatically, not embedded fixtures.
+- `#doodle-wall` hash-open routes through `stepIn()` — no private open-channel for the
+  overlay; mode-keyed chrome yields on every tier.
+- `submit()` continuation is visit-guarded — exit during `submitting` cannot clobber the
+  next visit's phase.
+- One stroke, one pointer — secondary touches/buttons cannot orphan a live stroke.
+- Deterministic rejections (too-large, 400/403) get distinct error cards; only transient
+  failures offer Try again.
+- Byte-accurate body ceiling + Content-Length pre-check.
+- **Anon INSERT policy dropped from the migration** — writes are service-role only.
+- Production tripwire: partial Supabase env throws rather than silently serving fakes.
+- Failed row insert compensates by removing the just-uploaded PNG
+  (`TileImageStore.remove()`).
+- `getWall()` projects to the public `WallTile` shape at the domain boundary; the type
+  lives in `src/lib/doodle-wall/types.ts`, config re-exports it.
+- `StaticCv`'s `#doodle-wall` link has a server-rendered target.
+- `DoodleWall` has its own `?off=doodle` debug key.
+- Daily-cap count-then-insert TOCTOU is **accepted and documented** (worst case: a
+  racer lands one tile over cap; pre-moderation queue absorbs it).
+
+**Parked follow-ons (verified in review, deliberately not fixed — pick up post-merge):**
+
+- Card chrome triplicated across `overlays/BallTossHud.tsx` / `HighStrikerHud.tsx` /
+  `DoodleWallHud.tsx` → extract a shared `overlays/CardShell`.
+- `/api/wall` fetch duplicated between `three/game/DoodleWall.tsx` and
+  `overlays/DoodleWallHud.tsx` → shared `fetchWallTiles` helper.
+- Fortune/tiles route preamble + rate-limit factory duplication → shared `src/lib/api`
+  helpers.
+- `stepIn()` per-stall reset ternary accretion in `src/store/scene.ts` → data-driven
+  `FRESH_ON_STEP_IN` map.
+- Undo-bake allocates a fresh canvas + 1MB readback per stroke past depth 20
+  (`DoodleWallHud.tsx`) → persistent baked canvas.
+- Submit ships base64 JSON (4 buffer passes) → `toBlob` + raw body (contract change —
+  renegotiate §2.1 when taken).
+- Daily-cap count uses `count: 'exact'` unbounded (`src/lib/supabase/tileRepository.ts`)
+  → `limit(cap)` probe.
+- `DoodleWall.tsx` halo block duplicates `BulbGlow`'s sprite policy → shared
+  `HaloPoints`.
+- Glossary-guard advisory: `resume-*` section ids in `src/components/cv/StaticCv.tsx`
+  extend a pre-existing convention — a follow-on sweep should rename the whole family to
+  `cv-*` (CV, not resume, per CONTEXT.md).
 
 **Open:**
 
 - Admin queue UX details (batch approve, preview size) — resolve at Stage 2 start.
-- Exact stall placement on the Midway (after contact, per CONTEXT.md order) — iterate
-  visually during the scene slice.
 
 **Needs Nick (human gates):**
 
 - **Provisioning gate (before real Supabase goes live):** create the Supabase project →
   run the migration (it also creates the `tiles` bucket) → set the four env vars (local
-  - Vercel). Until then everything runs in stub mode. Note: Supabase env present but
-    `SUBMITTER_HASH_SECRET` missing throws at request time — by design.
+  - Vercel). Until then everything runs in stub mode. Partial env in production throws —
+    set all four together.
+- **Real-GPU look pass** on the stall, board grid and overlay — headless swiftshader
+  screenshots guided placement, but final feel is judged on Nick's Mac. Still
+  outstanding.
 - Stage 2 admin allow-list uses Nick's actual Google identity — collect it at Stage 2
   start; never widen to "any Google login" (ADR-0001).
-- Final look/feel judgement on his Mac (real GPU).
 
 ## 6. How to verify
 
 - **Gate (every slice):** `pnpm typecheck && pnpm lint && pnpm test:ci && pnpm build`
-  (currently 111 tests, keyless).
-- **Domain + routes:** ✅ covered — `tileService`/`png`/`submitterHash` unit tests
-  against fakes; route handler tests (rate-limit, 400s, approved-only wall). Config
-  helpers go in `doodleWallConfig.test.ts` (scene slice).
-- **Scene:** headless Playwright + swiftshader screenshots (recipe and iso-camera maths in
-  `ball-toss-game-handoff.md` §6; drive state via `?debug=1` + `window.__sceneStore`).
-  Check the wall grid renders and the overlay opens on step-in, on Full and Lite.
-- **End-to-end (Supabase staging, after provisioning):** draw → submit → row is `pending`
-  and NOT on the wall → approve → tile appears on next `/api/wall` load. Non-allow-listed
-  Google account is denied `/admin`.
-- **Degradation:** WebGL off → tiles render as `<img>`.
+  — all green at `c43bf60` (120 tests, keyless).
+- **Domain + routes + config:** ✅ covered by colocated unit tests against fakes.
+- **Scene/overlay headless:** recipe in `ball-toss-game-handoff.md` §6 (Playwright +
+  swiftshader, `?debug=1` + `window.__sceneStore`; `?off=doodle` isolates the wall).
+  Builder screenshots predate the review fixes — a headless re-verify of the
+  `#doodle-wall` hash entry and the new error cards is **optional but recommended**
+  before the PR (behaviour changed since those shots).
+- **End-to-end (Supabase staging, after provisioning):** draw → submit → row `pending`
+  and NOT on the wall → approve → tile appears on next `/api/wall` load.
+  Non-allow-listed Google account denied `/admin` (Stage 2).
+- **Degradation:** WebGL off → `StaticCv` link → overlay with `<img>` tiles.
 
 ## 7. Gotchas (inherited — details in `ball-toss-game-handoff.md` §7)
 
-- R3F lint rules: mutate refs only in `useFrame`/handlers; per-frame sim state in refs,
-  only summaries in the store.
+- R3F lint rules: mutate refs only in `useFrame`/handlers; per-frame state in refs, only
+  summaries in the store.
 - Low tier runs `frameloop='demand'` — call `invalidate()` while anything animates.
 - No EffectComposer/bloom additions; emissive + `BulbGlow` sprites only.
 - Spawned GLB props rendering black → `material.vertexColors = false`.
 - Never `rm -rf .next` while a dev server runs; clean prod build for verification.
-- No `@react-three/*` imports in the static bundle; overlays may import three-free config
-  modules only (`doodleWallConfig.ts` must stay three-free).
-- Tile PNGs are user content: treat as untrusted (validate server-side, cap dimensions and
-  bytes, re-encode or content-type-pin on serve; no SVG).
-- `pnpm knip` flags `DRAWING_CANVAS_SIZE`/`SCENE_TILE_COUNT` until the scene/overlay
-  slice consumes them — expected, resolves itself.
+- No `@react-three/*` imports in the static bundle; overlays may import three-free
+  config modules only (`doodleWallConfig.ts` must stay three-free).
+- Tile PNGs are user content: treat as untrusted (validate server-side, cap dimensions
+  and bytes; no SVG).
 - `GET /api/wall` `imageUrl` is a data URI in stub mode, an https Storage URL with
   Supabase — scene textures and overlay `<img>`s must handle both.
-- Nick's dev server usually holds port 3000 — smoke servers go on a spare port (backend
-  slice used 3100).
+- Bisection keys: `?off=doodle` unmounts the wall; `?off=game` covers only the game sims.
+- Nick's dev server usually holds port 3000 — smoke servers go on a spare port.
 - Commit messages end `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
 
 ## 8. Build order
 
-1. ~~Grill session closes §5 open decisions~~ ✅ done 2026-07-14; outcomes in §5.
-2. ~~Domain layer + fake adapters + unit tests~~ ✅ done (`58bf8ad`); server truths in
-   `src/lib/doodle-wall/constants.ts`, to be re-exported by `doodleWallConfig.ts`.
-3. ~~Routes (thin) against the fake adapter; stub mode; Supabase adapters dormant~~ ✅
-   done (`6d758dc`); contracts in §2.1.
-4. Scene: attraction entry + stall + wall grid fed by `/api/wall` (stub data).
-5. Overlay: drawing surface + submit flow + store slice.
-6. Swap in real Supabase adapter behind the ports once Nick provisions (gate).
-7. Close-out: glossary-guard → /code-review (high) → docs-scribe → absorb here.
-8. Stage 2: admin + keepalive, same shape.
+1. ~~Grill session closes open decisions~~ ✅ 2026-07-14; outcomes in §5.
+2. ~~Domain layer + fake adapters + unit tests~~ ✅ (`58bf8ad`).
+3. ~~Routes (thin), stub mode, dormant Supabase adapters~~ ✅ (`6d758dc`); contracts §2.1.
+4. ~~Scene: attraction entry + stall + wall grid~~ ✅ (`f06f27a`, `20ecc3c`, `bc376a7`).
+5. ~~Overlay: drawing surface + submit flow + store slice~~ ✅ (`c600659`, `c902fa5`).
+6. ~~Close-out: glossary-guard → /code-review (high) → docs-scribe → absorb~~ ✅
+   (`5a2df8d`, `c43bf60`; docs-scribe + this absorb 2026-07-14).
+7. **Raise the Stage 1 PR** (target `master`). Optional first: headless re-verify of
+   hash entry + error cards (§6).
+8. Swap in real Supabase behind the ports once Nick provisions (gate) + his real-GPU
+   look pass.
+9. Stage 2: admin + keepalive, same shape (brief from this doc; contracts in §2.1).
 
 ## 9. What just happened
 
-2026-07-14 — **Stage 1 data + backend slice landed** (`58bf8ad` domain layer, `6d758dc`
-routes/adapters/migration/env, `d28b50d` comment reword). Gate green (111 tests,
-keyless); supabase-js confinement grep-verified; smoke-tested on port 3100. Route
-contracts and server truths recorded in §2.1; accepted deviations in §5. Earlier the
-same day: branch cut from `9360f16`, `carnival-context` agent created, doc seeded, grill
-session closed all open parameters. Next: the scene + overlay slice (§8 steps 4–5), then
-the Supabase provisioning gate (Needs Nick).
+2026-07-14 (later) — **Stage 1 scene + overlay slice landed and the close-out chain
+ran.** Scene slice: `f06f27a` (config), `c600659` (store slice), `20ecc3c` (stall +
+board), `c902fa5` (step-in overlay), `bc376a7` (final placement — board rides the
+roofline at the Midway's end). Close-out: glossary-guard `5a2df8d` ('slot' reworded,
+**the carny** added to `CONTEXT.md`, HUD enumeration updated; one advisory parked —
+`resume-*` → `cv-*` sweep, §5); /code-review high `c43bf60` (12 confirmed findings
+fixed, §5; 8 verified cleanup findings deliberately parked, §5). Gate green at
+`c43bf60`: typecheck / lint / test:ci 120 / build. docs-scribe sync ran with this
+absorb. Next: the Stage 1 PR (§8 step 7), then the provisioning gate and Nick's
+real-GPU pass (Needs Nick).

--- a/docs/redesign/open-questions.md
+++ b/docs/redesign/open-questions.md
@@ -17,11 +17,10 @@
 
 ## Doodle wall
 
-- **Tile size** (≈256×256?), **how many** approved tiles shown on the wall (50? 100?), and **age-out rule**.
-- **Drawing tools** — brush sizes, colour palette (neon palette only, to stay on-theme?), undo, clear.
-- **Rate-limit values** (submissions per session/IP per day) and the `submitter_hash` basis.
-- **Tile frame** visual (neon polaroid? bulb-framed?).
-- Admin queue UX details (batch approve, preview size).
+- ~~Tile size, wall bound + age-out, drawing tools, rate-limit values + `submitter_hash`
+  basis, tile frame visual, display surface~~ ✅ **Resolved** (grill session 2026-07-14) —
+  decisions recorded in `doodle-wall-handoff.md` §5.
+- Admin queue UX details (batch approve, preview size) — resolve at Stage 2.
 
 ## Blog
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@react-three/fiber": "^9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "@sentry/nextjs": "^10.65.0",
+    "@supabase/supabase-js": "^2.110.2",
     "@varlock/nextjs-integration": "1.1.4",
     "@vercel/analytics": "^2.0.1",
     "ai": "^7.0.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.65.0
         version: 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(react@19.2.7)(webpack@5.108.4)
+      '@supabase/supabase-js':
+        specifier: ^2.110.2
+        version: 2.110.2
       '@varlock/nextjs-integration':
         specifier: 1.1.4
         version: 1.1.4(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(varlock@1.10.0)
@@ -1474,6 +1477,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.110.2':
+    resolution: {integrity: sha512-Qj7a6EDP+AMMQFWqGv+qFa8r6re//dk+qQI5bA0KK+PZmnI3JPu97TDeNt6SMiQ2FkklP79hP2yDFYSnA989OA==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/functions-js@2.110.2':
+    resolution: {integrity: sha512-ZjjqrXpxM9/rE+eAtZxiK45EWy9EBoJQ322Q5Y75LccYQNh212neHTgXP/o4MIzmH0LNXT8UzvTZtQOfOzyoeQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/phoenix@0.4.4':
+    resolution: {integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==}
+
+  '@supabase/postgrest-js@2.110.2':
+    resolution: {integrity: sha512-++LBmcIMwCtgO4tISQUmo9+2xkRwHQqS8ZKMCnhXLe9P8k8YQRXuMoh/RiSzQSoev8gqet0W7yOboW0cUxnt0Q==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/realtime-js@2.110.2':
+    resolution: {integrity: sha512-z3jTOTPgyn6E3r6dVOOQ10He4yAMB2czjFw7xVdX3s16MHElna5rY1gVaePs0NIo6xvtMYbtmOXlFaFt/ePLpg==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/storage-js@2.110.2':
+    resolution: {integrity: sha512-EhsRSwSnmQefKJsAxoRUZ0hvHr92ECM8DDGAKR5z0HdoJx4heI60PjHUTruVNZxKX6XeobLGDyLud020Bw1iwg==}
+    engines: {node: '>=22.0.0'}
+
+  '@supabase/supabase-js@2.110.2':
+    resolution: {integrity: sha512-r9q9w4ZQ6mOjh36aqUNFSisBF611vzpO8JphBESr2Q1SWvmGFQeI7Jq7Y+PaNMZ6Zszz+S2yTlJStCpnaMSnQg==}
+    engines: {node: '>=22.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2591,6 +2621,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -5156,6 +5190,38 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.110.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.110.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.4': {}
+
+  '@supabase/postgrest-js@2.110.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.110.2':
+    dependencies:
+      '@supabase/phoenix': 0.4.4
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.110.2':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.110.2':
+    dependencies:
+      '@supabase/auth-js': 2.110.2
+      '@supabase/functions-js': 2.110.2
+      '@supabase/postgrest-js': 2.110.2
+      '@supabase/realtime-js': 2.110.2
+      '@supabase/storage-js': 2.110.2
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -6385,6 +6451,8 @@ snapshots:
       - supports-color
 
   husky@9.1.7: {}
+
+  iceberg-js@0.8.1: {}
 
   ieee754@1.2.1: {}
 

--- a/src/app/api/tiles/rateLimit.ts
+++ b/src/app/api/tiles/rateLimit.ts
@@ -1,0 +1,32 @@
+import { RateLimiterMemory } from 'rate-limiter-flexible';
+
+import { SUBMIT_BURST_PER_MINUTE } from '@/lib/doodle-wall/constants';
+
+/**
+ * Best-effort in-memory burst guard for tile submissions (mirrors
+ * api/fortune/rateLimit.ts): per-IP, SUBMIT_BURST_PER_MINUTE points per
+ * sliding minute. Serverless instances each keep their own counters, so
+ * this under-counts across regions/cold starts — accepted for the burst
+ * guard, because the 10-per-day cap is enforced durably by counting rows
+ * through the repository port in tileService instead. For real
+ * cross-instance limiting, swap RateLimiterMemory for RateLimiterRedis;
+ * the route only calls checkBurstLimit(), so the swap stays here.
+ */
+
+let perIp = new RateLimiterMemory({ points: SUBMIT_BURST_PER_MINUTE, duration: 60 });
+
+export type BurstVerdict = 'ok' | 'rate-limited';
+
+export async function checkBurstLimit(ip: string): Promise<BurstVerdict> {
+  try {
+    await perIp.consume(ip, 1);
+    return 'ok';
+  } catch {
+    return 'rate-limited';
+  }
+}
+
+/** Test hook: reset the counters between cases. */
+export function resetBurstLimit(): void {
+  perIp = new RateLimiterMemory({ points: SUBMIT_BURST_PER_MINUTE, duration: 60 });
+}

--- a/src/app/api/tiles/route.test.ts
+++ b/src/app/api/tiles/route.test.ts
@@ -1,0 +1,148 @@
+import { Buffer } from 'node:buffer';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeNoisePng, makeSolidPng, type InMemoryTileRepository } from '@/lib/doodle-wall/fakes';
+import { hashSubmitter } from '@/lib/doodle-wall/submitterHash';
+import {
+  DEV_SUBMITTER_HASH_SECRET,
+  getTileAdapters,
+  resetTileAdapters,
+} from '@/lib/supabase/tileAdapters';
+
+import { resetBurstLimit } from './rateLimit';
+import { POST } from './route';
+
+/**
+ * Route-handler tests, keyless (stub mode) and offline: the factory wires
+ * the in-memory fakes because no SUPABASE_* env is set.
+ */
+
+const VALID_IMAGE = Buffer.from(makeSolidPng(256, [255, 64, 129])).toString('base64');
+
+const post = (body: unknown, headers: Record<string, string> = {}) =>
+  POST(
+    new Request('https://iamnick.dev/api/tiles', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        host: 'iamnick.dev',
+        'x-forwarded-for': '203.0.113.7',
+        ...headers,
+      },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    }),
+  );
+
+/** The stub-mode fake repository behind the factory, for direct inspection. */
+const fakeRepository = () => getTileAdapters().repository as InMemoryTileRepository;
+
+beforeEach(() => {
+  vi.stubEnv('SUPABASE_URL', '');
+  vi.stubEnv('SUPABASE_ANON_KEY', '');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '');
+  vi.stubEnv('SUBMITTER_HASH_SECRET', '');
+  resetTileAdapters();
+  resetBurstLimit();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('POST /api/tiles — validation', () => {
+  it('rejects malformed JSON with 400', async () => {
+    expect((await post('{nope')).status).toBe(400);
+  });
+
+  it('rejects a missing, empty, or non-base64 image with 400', async () => {
+    expect((await post({})).status).toBe(400);
+    expect((await post({ image: '' })).status).toBe(400);
+    expect((await post({ image: 'not base64 !!!' })).status).toBe(400);
+    expect((await post({ image: 42 })).status).toBe(400);
+  });
+
+  it('rejects oversized raw bodies with 413 before parsing', async () => {
+    const res = await post(`{"image":"${'A'.repeat(210_000)}"}`);
+    expect(res.status).toBe(413);
+  });
+
+  it('rejects cross-origin and malformed-origin requests with 403', async () => {
+    expect((await post({ image: VALID_IMAGE }, { origin: 'https://evil.example' })).status) //
+      .toBe(403);
+    expect((await post({ image: VALID_IMAGE }, { origin: 'not a url' })).status).toBe(403);
+  });
+
+  it('rejects base64 that is not a 256×256 PNG with 400', async () => {
+    const wrongSize = Buffer.from(makeSolidPng(512, [0, 0, 0])).toString('base64');
+    const res = await post({ image: wrongSize });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid-image' });
+  });
+
+  it('rejects a valid PNG over the byte cap with 413', async () => {
+    const oversized = Buffer.from(makeNoisePng(256)).toString('base64');
+    const res = await post({ image: oversized });
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'too-large' });
+  });
+});
+
+describe('POST /api/tiles — submission', () => {
+  it('accepts a valid tile with 201 and a pending-only contract', async () => {
+    const res = await post({ image: VALID_IMAGE }, { origin: 'https://iamnick.dev' });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; status: string; createdAt: string };
+    expect(body.status).toBe('pending');
+    expect(body.id).toBeTruthy();
+    expect(Date.parse(body.createdAt)).not.toBeNaN();
+  });
+
+  it('never lands a smuggled status — the tile stays pending', async () => {
+    const res = await post({ image: VALID_IMAGE, status: 'approved' });
+    expect(res.status).toBe(201);
+    const stored = fakeRepository()
+      .all()
+      .find((tile) => tile.submitterHash !== 'seed');
+    expect(stored?.status).toBe('pending');
+    // And it never surfaces on the wall.
+    const wall = await fakeRepository().recentApproved(48);
+    expect(wall.some((tile) => tile.id === stored?.id)).toBe(false);
+  });
+
+  it('stores the submitter as an HMAC of the IP, never the raw IP', async () => {
+    await post({ image: VALID_IMAGE });
+    const stored = fakeRepository()
+      .all()
+      .find((tile) => tile.submitterHash !== 'seed');
+    expect(stored?.submitterHash).toBe(hashSubmitter('203.0.113.7', DEV_SUBMITTER_HASH_SECRET));
+  });
+});
+
+describe('POST /api/tiles — rate limiting', () => {
+  it('429s the 3rd submission inside a minute from one IP (burst guard)', async () => {
+    expect((await post({ image: VALID_IMAGE })).status).toBe(201);
+    expect((await post({ image: VALID_IMAGE })).status).toBe(201);
+    const res = await post({ image: VALID_IMAGE });
+    expect(res.status).toBe(429);
+    expect(await res.json()).toEqual({ error: 'rate-limited' });
+  });
+
+  it('429s when the durable daily cap is already spent for the hash', async () => {
+    const hash = hashSubmitter('203.0.113.7', DEV_SUBMITTER_HASH_SECRET);
+    const repository = fakeRepository();
+    for (let i = 0; i < 10; i++) {
+      await repository.insert({
+        id: `capped-${i}`,
+        imagePath: `capped-${i}.png`,
+        imageUrl: 'data:image/png;base64,',
+        status: 'pending',
+        submitterHash: hash,
+        createdAt: new Date().toISOString(),
+      });
+    }
+    const res = await post({ image: VALID_IMAGE });
+    expect(res.status).toBe(429);
+    expect(await res.json()).toEqual({ error: 'rate-limited' });
+  });
+});

--- a/src/app/api/tiles/route.ts
+++ b/src/app/api/tiles/route.ts
@@ -61,8 +61,16 @@ export async function POST(req: Request): Promise<Response> {
     }
   }
 
+  // Refuse by declared size before buffering anything; the header is only a
+  // claim, so the buffered body is re-measured after. Buffer.byteLength, not
+  // String#length — length counts UTF-16 code units, and a multibyte-padded
+  // body can be ~3× the byte cap while passing a code-unit check.
+  const declared = Number(req.headers.get('content-length'));
+  if (declared > MAX_BODY_BYTES) return Response.json({ error: 'too-large' }, { status: 413 });
   const raw = await req.text();
-  if (raw.length > MAX_BODY_BYTES) return Response.json({ error: 'too-large' }, { status: 413 });
+  if (Buffer.byteLength(raw) > MAX_BODY_BYTES) {
+    return Response.json({ error: 'too-large' }, { status: 413 });
+  }
   let body: unknown;
   try {
     body = JSON.parse(raw);

--- a/src/app/api/tiles/route.ts
+++ b/src/app/api/tiles/route.ts
@@ -1,0 +1,95 @@
+import { Buffer } from 'node:buffer';
+
+import { z } from 'zod';
+
+import { hashSubmitter } from '@/lib/doodle-wall/submitterHash';
+import { createTileService, type SubmitTileResult } from '@/lib/doodle-wall/tileService';
+import { getTileAdapters } from '@/lib/supabase/tileAdapters';
+
+import { checkBurstLimit } from './rateLimit';
+
+/**
+ * POST /api/tiles — submit one tile to the doodle wall's pre-moderation
+ * queue (ADR-0001). Thin HTTP adapter over tileService: parse → burst
+ * guard → service; every acceptance rule (PNG header, exact 256×256,
+ * 128 KB cap, forced-pending status, durable daily cap) lives in the
+ * service, not here.
+ *
+ * Body: JSON `{ image: <base64 PNG, no data: prefix> }`.
+ * Responses: 201 `{ id, status: 'pending', createdAt }`; errors are
+ * `{ error }` with 400 invalid, 413 too large, 429 rate-limited (burst or
+ * daily cap), 403 bad origin.
+ *
+ * Node runtime, as fortune: rate-limiter-flexible and the (dormant)
+ * Supabase adapter want a full Node environment.
+ */
+export const runtime = 'nodejs';
+
+/**
+ * Raw-body ceiling, checked before JSON.parse: base64 of the 128 KB tile
+ * cap is ~175 KB, plus JSON envelope headroom. Anything larger cannot be a
+ * legal submission, so it is refused before any parsing work.
+ */
+const MAX_BODY_BYTES = 204_800;
+
+// Unknown keys (a smuggled `status`, say) are stripped by default — and the
+// service could not accept one anyway.
+const BodySchema = z.object({
+  image: z.base64().min(1),
+});
+
+const FAILURE_STATUS: Record<Extract<SubmitTileResult, { ok: false }>['reason'], number> = {
+  'invalid-image': 400,
+  'too-large': 413,
+  'daily-cap': 429,
+};
+
+export async function POST(req: Request): Promise<Response> {
+  // Origin check: browser requests carry Origin on cross-site POSTs — reject
+  // anything not from this site. (Requests without Origin, e.g. curl, are
+  // bounded by the rate limits below.)
+  const origin = req.headers.get('origin');
+  const host = req.headers.get('host');
+  if (origin && host) {
+    // A malformed Origin must read as forbidden, not crash the handler.
+    try {
+      if (new URL(origin).host !== host) {
+        return Response.json({ error: 'bad-origin' }, { status: 403 });
+      }
+    } catch {
+      return Response.json({ error: 'bad-origin' }, { status: 403 });
+    }
+  }
+
+  const raw = await req.text();
+  if (raw.length > MAX_BODY_BYTES) return Response.json({ error: 'too-large' }, { status: 413 });
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return Response.json({ error: 'invalid-request' }, { status: 400 });
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) return Response.json({ error: 'invalid-request' }, { status: 400 });
+
+  // Burst guard before any decoding or storage work (first x-forwarded-for
+  // hop, as fortune does).
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0].trim() ?? 'unknown';
+  if ((await checkBurstLimit(ip)) === 'rate-limited') {
+    return Response.json({ error: 'rate-limited' }, { status: 429 });
+  }
+
+  const adapters = getTileAdapters();
+  const service = createTileService(adapters);
+  const result = await service.submitTile({
+    imageBytes: new Uint8Array(Buffer.from(parsed.data.image, 'base64')),
+    submitterHash: hashSubmitter(ip, adapters.submitterHashSecret),
+  });
+
+  if (!result.ok) {
+    const error = result.reason === 'daily-cap' ? 'rate-limited' : result.reason;
+    return Response.json({ error }, { status: FAILURE_STATUS[result.reason] });
+  }
+  const { id, status, createdAt } = result.tile;
+  return Response.json({ id, status, createdAt }, { status: 201 });
+}

--- a/src/app/api/wall/route.test.ts
+++ b/src/app/api/wall/route.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WALL_TILE_COUNT } from '@/lib/doodle-wall/constants';
+import { seedApprovedTiles } from '@/lib/doodle-wall/fakes';
+import { getTileAdapters, resetTileAdapters } from '@/lib/supabase/tileAdapters';
+
+import { GET } from './route';
+
+/**
+ * Route-handler tests, keyless (stub mode) and offline: the factory wires
+ * the in-memory fakes because no SUPABASE_* env is set.
+ */
+
+interface WallTile {
+  id: string;
+  imageUrl: string;
+  createdAt: string;
+}
+
+const getWall = async () => {
+  const res = await GET();
+  return { res, body: (await res.json()) as { tiles: WallTile[] } };
+};
+
+beforeEach(() => {
+  vi.stubEnv('SUPABASE_URL', '');
+  vi.stubEnv('SUPABASE_ANON_KEY', '');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '');
+  resetTileAdapters();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('GET /api/wall', () => {
+  it('returns the seeded approved tiles as renderable data URIs', async () => {
+    const { res, body } = await getWall();
+    expect(res.status).toBe(200);
+    expect(body.tiles).toHaveLength(seedApprovedTiles().length);
+    expect(body.tiles[0].imageUrl).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it('exposes only id, imageUrl, createdAt — never hashes or paths', async () => {
+    const { body } = await getWall();
+    for (const tile of body.tiles) {
+      expect(Object.keys(tile).sort()).toEqual(['createdAt', 'id', 'imageUrl']);
+    }
+  });
+
+  it('orders newest first', async () => {
+    const { body } = await getWall();
+    const createdAts = body.tiles.map((tile) => tile.createdAt);
+    expect(createdAts).toEqual([...createdAts].sort().reverse());
+  });
+
+  it('excludes pending and rejected tiles', async () => {
+    const repository = getTileAdapters().repository;
+    const unapproved = seedApprovedTiles()[0];
+    await repository.insert({ ...unapproved, id: 'held', status: 'pending' });
+    await repository.insert({ ...unapproved, id: 'binned', status: 'rejected' });
+    const { body } = await getWall();
+    const ids = body.tiles.map((tile) => tile.id);
+    expect(ids).not.toContain('held');
+    expect(ids).not.toContain('binned');
+  });
+
+  it(`is bounded at WALL_TILE_COUNT (${WALL_TILE_COUNT})`, async () => {
+    const repository = getTileAdapters().repository;
+    const template = seedApprovedTiles()[0];
+    for (let i = 0; i < WALL_TILE_COUNT + 10; i++) {
+      await repository.insert({
+        ...template,
+        id: `extra-${i}`,
+        createdAt: new Date(Date.now() + i * 1000).toISOString(),
+      });
+    }
+    const { body } = await getWall();
+    expect(body.tiles).toHaveLength(WALL_TILE_COUNT);
+    // The newest inserted tile survives the bound.
+    expect(body.tiles[0].id).toBe(`extra-${WALL_TILE_COUNT + 9}`);
+  });
+
+  it('sends the CDN cache header (no realtime, ADR-0001)', async () => {
+    const { res } = await getWall();
+    expect(res.headers.get('Cache-Control')).toBe(
+      'public, s-maxage=60, stale-while-revalidate=300',
+    );
+  });
+});

--- a/src/app/api/wall/route.test.ts
+++ b/src/app/api/wall/route.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WALL_TILE_COUNT } from '@/lib/doodle-wall/constants';
 import { seedApprovedTiles } from '@/lib/doodle-wall/fakes';
+import type { WallTile } from '@/lib/doodle-wall/types';
 import { getTileAdapters, resetTileAdapters } from '@/lib/supabase/tileAdapters';
 
 import { GET } from './route';
@@ -10,12 +11,6 @@ import { GET } from './route';
  * Route-handler tests, keyless (stub mode) and offline: the factory wires
  * the in-memory fakes because no SUPABASE_* env is set.
  */
-
-interface WallTile {
-  id: string;
-  imageUrl: string;
-  createdAt: string;
-}
 
 const getWall = async () => {
   const res = await GET();

--- a/src/app/api/wall/route.ts
+++ b/src/app/api/wall/route.ts
@@ -1,0 +1,25 @@
+import { createTileService } from '@/lib/doodle-wall/tileService';
+import { getTileAdapters } from '@/lib/supabase/tileAdapters';
+
+/**
+ * GET /api/wall — the doodle wall: most-recent approved tiles, newest
+ * first, bounded at WALL_TILE_COUNT (48). Only public fields leave the
+ * server; submitter hashes and storage paths never do.
+ *
+ * Response: `{ tiles: [{ id, imageUrl, createdAt }] }`.
+ *
+ * Cacheable at the CDN — the wall is persisted, not live (no realtime,
+ * ADR-0001), so a newly approved tile appearing within a minute is fine.
+ */
+export const runtime = 'nodejs';
+
+const CACHE_CONTROL = 'public, s-maxage=60, stale-while-revalidate=300';
+
+export async function GET(): Promise<Response> {
+  const service = createTileService(getTileAdapters());
+  const tiles = await service.getWall();
+  return Response.json(
+    { tiles: tiles.map(({ id, imageUrl, createdAt }) => ({ id, imageUrl, createdAt })) },
+    { headers: { 'Cache-Control': CACHE_CONTROL } },
+  );
+}

--- a/src/app/api/wall/route.ts
+++ b/src/app/api/wall/route.ts
@@ -17,9 +17,8 @@ const CACHE_CONTROL = 'public, s-maxage=60, stale-while-revalidate=300';
 
 export async function GET(): Promise<Response> {
   const service = createTileService(getTileAdapters());
+  // getWall already returns the public WallTile projection — private fields
+  // are stripped at the domain boundary, not here.
   const tiles = await service.getWall();
-  return Response.json(
-    { tiles: tiles.map(({ id, imageUrl, createdAt }) => ({ id, imageUrl, createdAt })) },
-    { headers: { 'Cache-Control': CACHE_CONTROL } },
-  );
+  return Response.json({ tiles }, { headers: { 'Cache-Control': CACHE_CONTROL } });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { AudioDirector } from '@/components/overlays/AudioDirector';
 import { TicketHud } from '@/components/overlays/TicketHud';
 import { BallTossHud } from '@/components/overlays/BallTossHud';
 import { HighStrikerHud } from '@/components/overlays/HighStrikerHud';
+import { DoodleWallHud } from '@/components/overlays/DoodleWallHud';
 
 /**
  * Homepage — the isometric, explorable Dark Carnival.
@@ -38,6 +39,10 @@ export default function Homepage() {
 
       {/* DOM overlay for the high-striker game (gauge / swings / verdict) */}
       <HighStrikerHud />
+
+      {/* Step-in overlay for the doodle wall (approved tiles + drawing surface);
+          also the wall's home for no-canvas visitors via StaticCv's #doodle-wall link */}
+      <DoodleWallHud />
 
       {/* Golden-ticket hunt tally + full-house modal */}
       <TicketHud />

--- a/src/components/cv/StaticCv.tsx
+++ b/src/components/cv/StaticCv.tsx
@@ -87,6 +87,16 @@ export function StaticCv() {
         </p>
       </section>
 
+      <section aria-labelledby="resume-doodle-wall">
+        <h2 id="resume-doodle-wall">Doodle wall</h2>
+        <p>
+          Visitors to the carnival leave a drawing behind — a wall of tiles, one per visitor.{' '}
+          {/* The overlay is the wall's home when the 3-D scene doesn't mount
+              (reduced motion / no WebGL): this link opens it directly. */}
+          <a href="#doodle-wall">Open the doodle wall</a> to see the latest tiles and draw your own.
+        </p>
+      </section>
+
       <section aria-labelledby="resume-contact">
         <h2 id="resume-contact">Contact</h2>
         <ul>

--- a/src/components/cv/StaticCv.tsx
+++ b/src/components/cv/StaticCv.tsx
@@ -87,7 +87,10 @@ export function StaticCv() {
         </p>
       </section>
 
-      <section aria-labelledby="resume-doodle-wall">
+      {/* id="doodle-wall": the link target must exist in server-rendered DOM
+          (no-JS, reader mode, pre-hydration) — the hash lands here; once
+          hydrated, DoodleWallHud's hash listener opens the overlay too. */}
+      <section id="doodle-wall" aria-labelledby="resume-doodle-wall">
         <h2 id="resume-doodle-wall">Doodle wall</h2>
         <p>
           Visitors to the carnival leave a drawing behind — a wall of tiles, one per visitor.{' '}

--- a/src/components/overlays/DoodleWallHud.tsx
+++ b/src/components/overlays/DoodleWallHud.tsx
@@ -1,0 +1,600 @@
+'use client';
+
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+import { FocusTrap } from 'focus-trap-react';
+
+import { type DoodleWallPhase, useSceneStore } from '@/store/scene';
+import { EASE } from '@/lib/motion';
+import { useKeyDown } from '@/hooks/useKeyDown';
+import {
+  BRUSH_SIZES,
+  DRAWING_CANVAS_SIZE,
+  GRID_COLS,
+  INK_PALETTE,
+  STORED_TILE_SIZE,
+  SUBMIT_BURST_PER_MINUTE,
+  SUBMIT_DAILY_CAP,
+  SUBMIT_FEEDBACK_MIN_MS,
+  TILE_GROUND,
+  TILE_MAX_BYTES,
+  UNDO_DEPTH,
+  WALL_TILE_COUNT,
+  type WallTile,
+} from '@/components/three/game/doodleWallConfig';
+
+// NB: no @react-three/* imports — static bundle (doodleWallConfig is three-free).
+
+/**
+ * DoodleWallHud — the doodle wall's step-in overlay (DOM sibling of the other
+ * HUDs). Shows BOTH halves of the wall: every approved tile from GET /api/wall
+ * as an <img> grid, and the drawing surface — a 512×512 <canvas> exported as a
+ * 256×256 PNG and POSTed to /api/tiles into the pre-moderation queue.
+ *
+ * Active two ways:
+ *  - step-in: `mode === 'playing' && activeStall === 'doodle-wall'` (Full AND
+ *    Lite — no quality gate, unlike ball-toss);
+ *  - the `#doodle-wall` link from StaticCv — the overlay is the wall's home on
+ *    the no-canvas tier (reduced motion / no WebGL), so it opens straight into
+ *    the wall view without the scene.
+ *
+ * Per-stroke state lives in refs (stroke list + a baked base past UNDO_DEPTH);
+ * only summaries touch React state / the store. Tools per the 2026-07-14 grill:
+ * fixed near-black tile ground, six neon inks, three brushes, undo (20), clear
+ * — no eraser, no text tool. Touch and pointer are both first-class (pointer
+ * events + touch-action: none). `<WallView>` remounts per visit, so every stay
+ * starts from a fresh tile ground without effect-driven state resets.
+ */
+
+interface Stroke {
+  hex: string;
+  size: number;
+  /** Flat x,y pairs in canvas pixels. */
+  pts: number[];
+}
+
+type ErrorKind = 'rate-limited' | 'failed';
+
+const CANVAS = DRAWING_CANVAS_SIZE;
+
+/* --- #doodle-wall hash as an external store (the StaticCv link's switch) --- */
+function subscribeToHash(onChange: () => void) {
+  window.addEventListener('hashchange', onChange);
+  return () => window.removeEventListener('hashchange', onChange);
+}
+const readHashOpen = () => window.location.hash === '#doodle-wall';
+const readHashOpenServer = () => false;
+
+function paintGround(ctx: CanvasRenderingContext2D) {
+  ctx.fillStyle = TILE_GROUND;
+  ctx.fillRect(0, 0, CANVAS, CANVAS);
+}
+
+function paintStroke(ctx: CanvasRenderingContext2D, s: Stroke) {
+  ctx.strokeStyle = s.hex;
+  ctx.lineWidth = s.size;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.beginPath();
+  ctx.moveTo(s.pts[0], s.pts[1]);
+  if (s.pts.length === 2) ctx.lineTo(s.pts[0] + 0.01, s.pts[1]); // a tap = a dot
+  for (let i = 2; i < s.pts.length; i += 2) ctx.lineTo(s.pts[i], s.pts[i + 1]);
+  ctx.stroke();
+}
+
+/** The shared letterpress card chrome (backdrop + dialog frame). */
+function CardShell({ children }: { children: ReactNode }) {
+  return (
+    <FocusTrap
+      focusTrapOptions={{
+        initialFocus: false,
+        escapeDeactivates: false,
+        allowOutsideClick: true,
+      }}
+    >
+      <motion.div
+        className="pointer-events-auto absolute inset-0 flex items-center justify-center p-4"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.25 }}
+      >
+        <div className="absolute inset-0 bg-background-primary/55 backdrop-blur-[2px]" />
+        <motion.div
+          role="dialog"
+          aria-modal="true"
+          initial={{ opacity: 0, y: 24, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 16, scale: 0.99 }}
+          transition={{ duration: 0.4, ease: EASE }}
+          className="ticket-frame halftone relative z-10 w-full max-w-md rounded-[5px] p-6 text-center md:p-8"
+        >
+          {children}
+        </motion.div>
+      </motion.div>
+    </FocusTrap>
+  );
+}
+
+export function DoodleWallHud() {
+  const storeActive = useSceneStore((s) => s.mode === 'playing' && s.activeStall === 'doodle-wall');
+  const phase = useSceneStore((s) => s.doodleWallPhase);
+  const setPhase = useSceneStore((s) => s.setDoodleWallPhase);
+  const exit = useSceneStore((s) => s.exit);
+
+  // The wall's no-canvas home: StaticCv links here with #doodle-wall, so
+  // reduced-motion / no-WebGL visitors reach the wall without the scene.
+  const linkOpen = useSyncExternalStore(subscribeToHash, readHashOpen, readHashOpenServer);
+  useEffect(() => {
+    // No scene to step in from — a link visit opens straight into the wall view.
+    if (linkOpen) useSceneStore.getState().setDoodleWallPhase('drawing');
+  }, [linkOpen]);
+
+  const active = storeActive || linkOpen;
+  const panelUp = active && phase !== 'intro';
+
+  const exitAll = useCallback(() => {
+    if (readHashOpen()) {
+      // drop the hash without adding a history entry, then let the hash
+      // subscribers re-read it (replaceState doesn't fire hashchange itself)
+      window.history.replaceState(null, '', window.location.pathname + window.location.search);
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    }
+    if (useSceneStore.getState().activeStall === 'doodle-wall') exit();
+  }, [exit]);
+
+  useKeyDown((e) => {
+    if (e.key === 'Escape') exitAll();
+  }, active);
+
+  return (
+    <AnimatePresence>
+      {active && (
+        <motion.div
+          className="pointer-events-none fixed inset-0 z-30"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+        >
+          {/* Exit ✕ takes the burger's exact slot (h-10 w-10, top-3 right-4),
+              matching the other HUDs. */}
+          <button
+            onClick={exitAll}
+            aria-label="Leave the doodle wall"
+            className="paper-button pointer-events-auto absolute right-4 top-3 z-20 flex h-10 w-10 items-center justify-center rounded-[4px] font-rye text-[15px]"
+          >
+            ✕
+          </button>
+
+          {/* The wall view remounts per visit — fresh tile ground every stay. */}
+          {panelUp && <WallView exitAll={exitAll} phase={phase} setPhase={setPhase} />}
+
+          {/* How-it-works card (step-in intro; the wall view isn't up yet). */}
+          <AnimatePresence>
+            {phase === 'intro' && (
+              <CardShell>
+                <p className="font-fell-sc text-[13px] tracking-[0.22em] text-brass-text">
+                  Leave your mark
+                </p>
+                <h2 className="font-rye letterpress mt-2 text-[34px] text-ink">Doodle Wall</h2>
+                <p className="font-fell mt-4 text-[15px] leading-relaxed text-ink/90">
+                  Every tile on this wall was drawn by a visitor. Pick a neon ink, doodle your own,
+                  and hand it to the carny — once it&apos;s approved, it hangs here for everyone who
+                  wanders past.
+                </p>
+                <button
+                  onClick={() => setPhase('drawing')}
+                  className="paper-button mt-6 rounded-[3px] px-6 py-3 font-fell-sc text-[15px] tracking-[0.06em]"
+                >
+                  Start drawing
+                </button>
+              </CardShell>
+            )}
+          </AnimatePresence>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+/**
+ * WallView — the drawing surface + the full approved wall, plus the submitted /
+ * error cards (they need the drawing to survive behind them). All per-stroke
+ * state lives here so a remount gives a clean slate.
+ */
+function WallView({
+  exitAll,
+  phase,
+  setPhase,
+}: {
+  exitAll: () => void;
+  phase: DoodleWallPhase;
+  setPhase: (p: DoodleWallPhase) => void;
+}) {
+  // --- The approved wall (all 48) — fetched fresh each visit ---
+  const [wall, setWall] = useState<WallTile[]>([]);
+  useEffect(() => {
+    let live = true;
+    fetch('/api/wall')
+      .then((r) => (r.ok ? (r.json() as Promise<{ tiles: WallTile[] }>) : null))
+      .then((data) => {
+        if (live && data) setWall(data.tiles.slice(0, WALL_TILE_COUNT));
+      })
+      .catch(() => {
+        /* the wall grid just stays empty; drawing still works */
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  // --- Drawing state: strokes in refs, summaries in React state ---
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const strokesRef = useRef<Stroke[]>([]);
+  const bakedRef = useRef<ImageData | null>(null);
+  const liveStrokeRef = useRef<Stroke | null>(null);
+  const [inkIndex, setInkIndex] = useState(0);
+  const [brushIndex, setBrushIndex] = useState(1);
+  const [strokeCount, setStrokeCount] = useState(0);
+  const [dirty, setDirty] = useState(false);
+  const [errorKind, setErrorKind] = useState<ErrorKind>('failed');
+
+  const getCtx = useCallback(
+    () => canvasRef.current?.getContext('2d', { willReadFrequently: true }) ?? null,
+    [],
+  );
+
+  // Paint the tile ground once on mount (external system, no state involved).
+  useEffect(() => {
+    const ctx = getCtx();
+    if (ctx) paintGround(ctx);
+  }, [getCtx]);
+
+  const redraw = useCallback(() => {
+    const ctx = getCtx();
+    if (!ctx) return;
+    paintGround(ctx);
+    if (bakedRef.current) ctx.putImageData(bakedRef.current, 0, 0);
+    for (const s of strokesRef.current) paintStroke(ctx, s);
+  }, [getCtx]);
+
+  /** Event-handler only (never from an effect): wipe back to the bare ground. */
+  const resetCanvas = () => {
+    strokesRef.current = [];
+    bakedRef.current = null;
+    liveStrokeRef.current = null;
+    redraw();
+    setStrokeCount(0);
+    setDirty(false);
+  };
+
+  const toCanvasXY = (e: React.PointerEvent<HTMLCanvasElement>): [number, number] => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    return [
+      ((e.clientX - rect.left) / rect.width) * CANVAS,
+      ((e.clientY - rect.top) / rect.height) * CANVAS,
+    ];
+  };
+
+  const onPointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (useSceneStore.getState().doodleWallPhase !== 'drawing') return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const [x, y] = toCanvasXY(e);
+    const stroke: Stroke = {
+      hex: INK_PALETTE[inkIndex].hex,
+      size: BRUSH_SIZES[brushIndex],
+      pts: [x, y],
+    };
+    liveStrokeRef.current = stroke;
+    const ctx = getCtx();
+    if (ctx) paintStroke(ctx, stroke); // the tap dot
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const stroke = liveStrokeRef.current;
+    if (!stroke) return;
+    const [x, y] = toCanvasXY(e);
+    const n = stroke.pts.length;
+    const [px, py] = [stroke.pts[n - 2], stroke.pts[n - 1]];
+    stroke.pts.push(x, y);
+    const ctx = getCtx();
+    if (ctx) {
+      // incremental segment — the full stroke is only replayed on undo/redraw
+      ctx.strokeStyle = stroke.hex;
+      ctx.lineWidth = stroke.size;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.beginPath();
+      ctx.moveTo(px, py);
+      ctx.lineTo(x, y);
+      ctx.stroke();
+    }
+  };
+
+  const onPointerEnd = () => {
+    const stroke = liveStrokeRef.current;
+    if (!stroke) return;
+    liveStrokeRef.current = null;
+    const strokes = strokesRef.current;
+    strokes.push(stroke);
+    // Undo runs UNDO_DEPTH deep: older strokes are baked into a base image.
+    if (strokes.length > UNDO_DEPTH) {
+      const off = document.createElement('canvas');
+      off.width = off.height = CANVAS;
+      const ctx = off.getContext('2d');
+      if (ctx) {
+        paintGround(ctx);
+        if (bakedRef.current) ctx.putImageData(bakedRef.current, 0, 0);
+        while (strokes.length > UNDO_DEPTH) paintStroke(ctx, strokes.shift() as Stroke);
+        bakedRef.current = ctx.getImageData(0, 0, CANVAS, CANVAS);
+      }
+    }
+    setStrokeCount(strokes.length);
+    setDirty(true);
+  };
+
+  const undo = () => {
+    const strokes = strokesRef.current;
+    if (!strokes.length) return;
+    strokes.pop();
+    redraw();
+    setStrokeCount(strokes.length);
+    if (!strokes.length && !bakedRef.current) setDirty(false);
+  };
+
+  // --- Submit: export 512 → 256 PNG, strip the data: prefix, POST ---
+  const submit = async () => {
+    const canvas = canvasRef.current;
+    if (!canvas || useSceneStore.getState().doodleWallPhase === 'submitting') return;
+    setPhase('submitting');
+    const started = performance.now();
+    try {
+      const out = document.createElement('canvas');
+      out.width = out.height = STORED_TILE_SIZE; // the server requires exactly 256×256
+      const ctx = out.getContext('2d');
+      if (!ctx) throw new Error('no-2d-context');
+      ctx.drawImage(canvas, 0, 0, STORED_TILE_SIZE, STORED_TILE_SIZE);
+      const image = out.toDataURL('image/png').replace(/^data:image\/png;base64,/, '');
+      // mirror the server's byte ceiling client-side (base64 → ~3/4 bytes)
+      if (image.length * 0.75 > TILE_MAX_BYTES) throw new Error('too-large');
+
+      const res = await fetch('/api/tiles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ image }),
+      });
+      // hold the submitting state briefly so it registers rather than flashes
+      const wait = SUBMIT_FEEDBACK_MIN_MS - (performance.now() - started);
+      if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+
+      if (res.status === 201) {
+        setPhase('submitted');
+        return;
+      }
+      setErrorKind(res.status === 429 ? 'rate-limited' : 'failed');
+      setPhase('error');
+    } catch {
+      setErrorKind('failed');
+      setPhase('error');
+    }
+  };
+
+  const drawAnother = () => {
+    resetCanvas();
+    setPhase('drawing');
+  };
+
+  return (
+    <>
+      <div className="pointer-events-auto absolute inset-0 overflow-y-auto bg-background-primary/55 backdrop-blur-[2px]">
+        <div className="mx-auto w-full max-w-5xl p-4 pb-8 pt-16 md:p-8 md:pt-16">
+          <div className="grid items-start gap-5 md:grid-cols-[minmax(0,10fr)_minmax(0,9fr)]">
+            {/* Drawing surface + tools */}
+            <section
+              aria-label="Draw your tile"
+              className="ticket-frame halftone rounded-[5px] p-4 md:p-5"
+            >
+              <p className="font-fell-sc text-[12px] tracking-[0.22em] text-brass-text">
+                Your tile
+              </p>
+              <canvas
+                ref={canvasRef}
+                width={CANVAS}
+                height={CANVAS}
+                onPointerDown={onPointerDown}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerEnd}
+                onPointerCancel={onPointerEnd}
+                aria-label="Drawing surface — draw with your pointer or finger"
+                className="mt-3 w-full cursor-crosshair touch-none rounded-[3px]"
+                style={{ backgroundColor: TILE_GROUND, aspectRatio: '1 / 1' }}
+              />
+
+              {/* Inks */}
+              <div
+                className="mt-4 flex flex-wrap items-center gap-2"
+                role="group"
+                aria-label="Neon inks"
+              >
+                {INK_PALETTE.map((ink, i) => (
+                  <button
+                    key={ink.hex}
+                    onClick={() => setInkIndex(i)}
+                    aria-label={`${ink.name} ink`}
+                    aria-pressed={i === inkIndex}
+                    className={`h-8 w-8 rounded-full transition-transform ${
+                      i === inkIndex
+                        ? 'scale-110 ring-2 ring-ink ring-offset-2'
+                        : 'opacity-80 hover:opacity-100'
+                    }`}
+                    style={{ backgroundColor: ink.hex }}
+                  />
+                ))}
+              </div>
+
+              {/* Brushes + undo/clear */}
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <div role="group" aria-label="Brush sizes" className="flex items-center gap-2">
+                  {BRUSH_SIZES.map((size, i) => (
+                    <button
+                      key={size}
+                      onClick={() => setBrushIndex(i)}
+                      aria-label={`${['Fine', 'Medium', 'Broad'][i]} brush`}
+                      aria-pressed={i === brushIndex}
+                      className={`paper-button flex h-9 w-9 items-center justify-center rounded-[3px] ${
+                        i === brushIndex ? 'ring-2 ring-ink' : ''
+                      }`}
+                    >
+                      <span
+                        aria-hidden
+                        className="block rounded-full bg-ink"
+                        style={{ width: 4 + i * 4, height: 4 + i * 4 }}
+                      />
+                    </button>
+                  ))}
+                </div>
+                <span aria-hidden className="text-ink-soft/50">
+                  |
+                </span>
+                <button
+                  onClick={undo}
+                  disabled={strokeCount === 0}
+                  className="paper-button rounded-[3px] px-3 py-2 font-fell-sc text-[13px] tracking-[0.06em] disabled:opacity-40"
+                >
+                  Undo
+                </button>
+                <button
+                  onClick={resetCanvas}
+                  disabled={!dirty}
+                  className="paper-button rounded-[3px] px-3 py-2 font-fell-sc text-[13px] tracking-[0.06em] disabled:opacity-40"
+                >
+                  Clear
+                </button>
+              </div>
+
+              <button
+                onClick={submit}
+                disabled={!dirty || phase === 'submitting'}
+                className="paper-button mt-4 w-full rounded-[3px] px-6 py-3 font-fell-sc text-[15px] tracking-[0.06em] disabled:opacity-40"
+              >
+                {phase === 'submitting' ? 'Handing it over…' : 'Hand it to the carny'}
+              </button>
+            </section>
+
+            {/* The approved wall — all 48, newest first */}
+            <section
+              aria-label="The doodle wall — approved tiles, newest first"
+              className="ticket-frame rounded-[5px] p-4 md:p-5"
+            >
+              <p className="font-fell-sc text-[12px] tracking-[0.22em] text-brass-text">The wall</p>
+              {wall.length > 0 ? (
+                <ul
+                  className="mt-3 grid list-none gap-1.5 p-0"
+                  style={{ gridTemplateColumns: `repeat(${GRID_COLS}, minmax(0, 1fr))` }}
+                >
+                  {wall.map((tile) => (
+                    <li key={tile.id}>
+                      {/* imageUrl is a data URI in stub mode, an https Storage
+                          URL with Supabase — <img> takes both. */}
+                      <img
+                        src={tile.imageUrl}
+                        alt="A visitor's tile"
+                        width={STORED_TILE_SIZE}
+                        height={STORED_TILE_SIZE}
+                        loading="lazy"
+                        className="w-full rounded-[2px]"
+                        style={{ backgroundColor: TILE_GROUND }}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="font-fell mt-3 text-[14px] italic text-ink-soft">
+                  The wall is bare — be the first to hang a tile.
+                </p>
+              )}
+            </section>
+          </div>
+        </div>
+      </div>
+
+      {/* Cards over the wall view: with-the-carny / error */}
+      <AnimatePresence>
+        {phase === 'submitted' && (
+          <CardShell>
+            <h2 className="font-rye letterpress text-[32px] text-ink">Handed to the carny</h2>
+            <p className="font-fell mt-3 text-[15px] leading-relaxed text-ink/90">
+              Your tile is in the pre-moderation queue — the carny shows every drawing to Nick
+              before it hangs. Check back soon and you might spot it on the wall.
+            </p>
+            <div className="mt-6 flex flex-wrap justify-center gap-3">
+              <button
+                onClick={drawAnother}
+                className="paper-button rounded-[3px] px-5 py-3 font-fell-sc text-[15px] tracking-[0.06em]"
+              >
+                Draw another
+              </button>
+              <button
+                onClick={exitAll}
+                className="paper-button rounded-[3px] px-5 py-3 font-fell-sc text-[14px] tracking-[0.06em]"
+              >
+                Back to the carnival
+              </button>
+            </div>
+          </CardShell>
+        )}
+
+        {phase === 'error' && errorKind === 'rate-limited' && (
+          <CardShell>
+            <h2 className="font-rye letterpress text-[30px] text-ink">
+              The carny&apos;s hands are full
+            </h2>
+            <p className="font-fell mt-3 text-[15px] leading-relaxed text-ink/90">
+              He takes {SUBMIT_BURST_PER_MINUTE} tiles a minute — and {SUBMIT_DAILY_CAP} a day —
+              from any one visitor. Catch your breath, admire the wall, and try again in a little
+              while. Your drawing is safe.
+            </p>
+            <button
+              onClick={() => setPhase('drawing')}
+              className="paper-button mt-6 rounded-[3px] px-5 py-3 font-fell-sc text-[15px] tracking-[0.06em]"
+            >
+              Back to the wall
+            </button>
+          </CardShell>
+        )}
+
+        {phase === 'error' && errorKind === 'failed' && (
+          <CardShell>
+            <h2 className="font-rye letterpress text-[30px] text-ink">The carny fumbled it</h2>
+            <p className="font-fell mt-3 text-[15px] leading-relaxed text-ink/90">
+              Your tile didn&apos;t make it across the counter — nothing lost, your drawing is still
+              here. Give it another go.
+            </p>
+            <div className="mt-6 flex flex-wrap justify-center gap-3">
+              <button
+                onClick={submit}
+                className="paper-button rounded-[3px] px-5 py-3 font-fell-sc text-[15px] tracking-[0.06em]"
+              >
+                Try again
+              </button>
+              <button
+                onClick={() => setPhase('drawing')}
+                className="paper-button rounded-[3px] px-5 py-3 font-fell-sc text-[14px] tracking-[0.06em]"
+              >
+                Keep drawing
+              </button>
+            </div>
+          </CardShell>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/src/components/overlays/DoodleWallHud.tsx
+++ b/src/components/overlays/DoodleWallHud.tsx
@@ -38,12 +38,12 @@ import {
  * as an <img> grid, and the drawing surface — a 512×512 <canvas> exported as a
  * 256×256 PNG and POSTed to /api/tiles into the pre-moderation queue.
  *
- * Active two ways:
- *  - step-in: `mode === 'playing' && activeStall === 'doodle-wall'` (Full AND
- *    Lite — no quality gate, unlike ball-toss);
- *  - the `#doodle-wall` link from StaticCv — the overlay is the wall's home on
- *    the no-canvas tier (reduced motion / no WebGL), so it opens straight into
- *    the wall view without the scene.
+ * Two entry paths, one open-channel: the store. A scene step-in sets
+ * `mode === 'playing' && activeStall === 'doodle-wall'` directly (Full AND
+ * Lite — no quality gate, unlike ball-toss); the `#doodle-wall` link from
+ * StaticCv (the wall's home on the no-canvas tier) is routed through
+ * `stepIn()` too, so everything keyed on `mode` — SiteNav's burger, the
+ * ticket tally — yields the chrome exactly as it does for the other stalls.
  *
  * Per-stroke state lives in refs (stroke list + a baked base past UNDO_DEPTH);
  * only summaries touch React state / the store. Tools per the 2026-07-14 grill:
@@ -60,7 +60,7 @@ interface Stroke {
   pts: number[];
 }
 
-type ErrorKind = 'rate-limited' | 'failed';
+type ErrorKind = 'rate-limited' | 'too-large' | 'rejected' | 'failed';
 
 const CANVAS = DRAWING_CANVAS_SIZE;
 
@@ -130,14 +130,20 @@ export function DoodleWallHud() {
   const exit = useSceneStore((s) => s.exit);
 
   // The wall's no-canvas home: StaticCv links here with #doodle-wall, so
-  // reduced-motion / no-WebGL visitors reach the wall without the scene.
+  // reduced-motion / no-WebGL visitors reach the wall without the scene. The
+  // hash is funnelled through stepIn() rather than opening the overlay on its
+  // own channel — mode-keyed chrome (burger, ticket tally) must never sit on
+  // top of the wall, and only `mode` can tell it so.
   const linkOpen = useSyncExternalStore(subscribeToHash, readHashOpen, readHashOpenServer);
   useEffect(() => {
-    // No scene to step in from — a link visit opens straight into the wall view.
-    if (linkOpen) useSceneStore.getState().setDoodleWallPhase('drawing');
+    if (!linkOpen) return;
+    const store = useSceneStore.getState();
+    store.stepIn('doodle-wall');
+    // A link visit has no fly-in to wait for — skip the intro, straight to the wall.
+    store.setDoodleWallPhase('drawing');
   }, [linkOpen]);
 
-  const active = storeActive || linkOpen;
+  const active = storeActive;
   const panelUp = active && phase !== 'intro';
 
   const exitAll = useCallback(() => {
@@ -241,16 +247,18 @@ function WallView({
   const strokesRef = useRef<Stroke[]>([]);
   const bakedRef = useRef<ImageData | null>(null);
   const liveStrokeRef = useRef<Stroke | null>(null);
+  /** The one pointer allowed to draw — a second touch (palm) must not steal the stroke. */
+  const activePointerRef = useRef<number | null>(null);
   const [inkIndex, setInkIndex] = useState(0);
   const [brushIndex, setBrushIndex] = useState(1);
   const [strokeCount, setStrokeCount] = useState(0);
   const [dirty, setDirty] = useState(false);
   const [errorKind, setErrorKind] = useState<ErrorKind>('failed');
 
-  const getCtx = useCallback(
-    () => canvasRef.current?.getContext('2d', { willReadFrequently: true }) ?? null,
-    [],
-  );
+  // No willReadFrequently: the visible canvas is never read back (bakes read
+  // from the offscreen canvas), and the flag would force CPU rasterisation of
+  // the hottest path here — the per-pointermove stroke segment.
+  const getCtx = useCallback(() => canvasRef.current?.getContext('2d') ?? null, []);
 
   // Paint the tile ground once on mount (external system, no state involved).
   useEffect(() => {
@@ -271,6 +279,7 @@ function WallView({
     strokesRef.current = [];
     bakedRef.current = null;
     liveStrokeRef.current = null;
+    activePointerRef.current = null;
     redraw();
     setStrokeCount(0);
     setDirty(false);
@@ -286,6 +295,11 @@ function WallView({
 
   const onPointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
     if (useSceneStore.getState().doodleWallPhase !== 'drawing') return;
+    // One stroke, one pointer: ignore secondary touches (palm) and non-primary
+    // buttons — otherwise a second pointerdown orphans the live stroke, leaving
+    // painted pixels the stroke list (and so undo/redraw) knows nothing about.
+    if (e.button !== 0 || activePointerRef.current !== null) return;
+    activePointerRef.current = e.pointerId;
     e.currentTarget.setPointerCapture(e.pointerId);
     const [x, y] = toCanvasXY(e);
     const stroke: Stroke = {
@@ -299,6 +313,7 @@ function WallView({
   };
 
   const onPointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (e.pointerId !== activePointerRef.current) return;
     const stroke = liveStrokeRef.current;
     if (!stroke) return;
     const [x, y] = toCanvasXY(e);
@@ -319,7 +334,9 @@ function WallView({
     }
   };
 
-  const onPointerEnd = () => {
+  const onPointerEnd = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (e.pointerId !== activePointerRef.current) return;
+    activePointerRef.current = null;
     const stroke = liveStrokeRef.current;
     if (!stroke) return;
     liveStrokeRef.current = null;
@@ -375,14 +392,30 @@ function WallView({
       const wait = SUBMIT_FEEDBACK_MIN_MS - (performance.now() - started);
       if (wait > 0) await new Promise((r) => setTimeout(r, wait));
 
+      // The visitor may have exited (and even re-stepped-in — stepIn resets the
+      // phase to 'intro') while the fetch was in flight; a stale continuation
+      // must not clobber the fresh visit.
+      if (useSceneStore.getState().doodleWallPhase !== 'submitting') return;
+
       if (res.status === 201) {
         setPhase('submitted');
         return;
       }
-      setErrorKind(res.status === 429 ? 'rate-limited' : 'failed');
+      // Distinguish the deterministic rejections from transient failures —
+      // "Try again" on an identical payload can never fix a 400/403/413.
+      setErrorKind(
+        res.status === 429
+          ? 'rate-limited'
+          : res.status === 413
+            ? 'too-large'
+            : res.status === 400 || res.status === 403
+              ? 'rejected'
+              : 'failed',
+      );
       setPhase('error');
-    } catch {
-      setErrorKind('failed');
+    } catch (err) {
+      if (useSceneStore.getState().doodleWallPhase !== 'submitting') return;
+      setErrorKind(err instanceof Error && err.message === 'too-large' ? 'too-large' : 'failed');
       setPhase('error');
     }
   };
@@ -561,6 +594,39 @@ function WallView({
               He takes {SUBMIT_BURST_PER_MINUTE} tiles a minute — and {SUBMIT_DAILY_CAP} a day —
               from any one visitor. Catch your breath, admire the wall, and try again in a little
               while. Your drawing is safe.
+            </p>
+            <button
+              onClick={() => setPhase('drawing')}
+              className="paper-button mt-6 rounded-[3px] px-5 py-3 font-fell-sc text-[15px] tracking-[0.06em]"
+            >
+              Back to the wall
+            </button>
+          </CardShell>
+        )}
+
+        {phase === 'error' && errorKind === 'too-large' && (
+          <CardShell>
+            <h2 className="font-rye letterpress text-[30px] text-ink">Too much ink for one tile</h2>
+            <p className="font-fell mt-3 text-[15px] leading-relaxed text-ink/90">
+              Your drawing is so detailed it won&apos;t fit through the carny&apos;s hatch. Undo a
+              few strokes — or Clear and go bolder with a broader brush — and hand it over again.
+            </p>
+            <button
+              onClick={() => setPhase('drawing')}
+              className="paper-button mt-6 rounded-[3px] px-5 py-3 font-fell-sc text-[15px] tracking-[0.06em]"
+            >
+              Back to the tile
+            </button>
+          </CardShell>
+        )}
+
+        {phase === 'error' && errorKind === 'rejected' && (
+          <CardShell>
+            <h2 className="font-rye letterpress text-[30px] text-ink">The carny turned it away</h2>
+            <p className="font-fell mt-3 text-[15px] leading-relaxed text-ink/90">
+              Something about the hand-over wasn&apos;t right, and trying the same tile again
+              won&apos;t change his mind. Your drawing is still on the surface — a fresh attempt
+              from the wall usually sorts it.
             </p>
             <button
               onClick={() => setPhase('drawing')}

--- a/src/components/three/Scene.tsx
+++ b/src/components/three/Scene.tsx
@@ -100,8 +100,11 @@ export default function Scene({ tier }: SceneProps) {
         {!dbg.off.has('glow') && <BulbGlow bloomOn={bloomOn} />}
         {!dbg.off.has('game') && <BallTossGame />}
         {!dbg.off.has('game') && <HighStrikerGame />}
-        {/* Scenery, not gated on mode: the tile board shows while travelling. */}
-        {!dbg.off.has('game') && <DoodleWall bloomOn={bloomOn} />}
+        {/* Scenery, not gated on mode: the tile board shows while travelling.
+            Own bisection key — ?off=game means "remove the game sims", and the
+            board (runtime texture fetches + additive halos) must be isolatable
+            on its own during a bloom/flicker hunt. */}
+        {!dbg.off.has('doodle') && <DoodleWall bloomOn={bloomOn} />}
         {!dbg.off.has('tickets') && <GoldenTickets bloomOn={bloomOn} />}
         <ConfettiBurst />
         {/* A child of Suspense: it only mounts once all the GLBs/textures above

--- a/src/components/three/Scene.tsx
+++ b/src/components/three/Scene.tsx
@@ -13,6 +13,7 @@ import { Indicators } from './synty/Indicators';
 import { DynamicLights } from './synty/DynamicLights';
 import { BallTossGame } from './game/BallTossGame';
 import { HighStrikerGame } from './game/HighStrikerGame';
+import { DoodleWall } from './game/DoodleWall';
 import { SafePostFX } from './effects/SafePostFX';
 import { LoaderVeil } from './intro/LoaderVeil';
 import { Atmosphere } from './synty/Atmosphere';
@@ -99,6 +100,8 @@ export default function Scene({ tier }: SceneProps) {
         {!dbg.off.has('glow') && <BulbGlow bloomOn={bloomOn} />}
         {!dbg.off.has('game') && <BallTossGame />}
         {!dbg.off.has('game') && <HighStrikerGame />}
+        {/* Scenery, not gated on mode: the tile board shows while travelling. */}
+        {!dbg.off.has('game') && <DoodleWall bloomOn={bloomOn} />}
         {!dbg.off.has('tickets') && <GoldenTickets bloomOn={bloomOn} />}
         <ConfettiBurst />
         {/* A child of Suspense: it only mounts once all the GLBs/textures above

--- a/src/components/three/game/DoodleWall.tsx
+++ b/src/components/three/game/DoodleWall.tsx
@@ -202,6 +202,15 @@ export function DoodleWall({ bloomOn = false }: { bloomOn?: boolean }) {
         <meshStandardMaterial color="#2a2333" />
       </mesh>
 
+      {/* Support poles down into the stall roof — the board rides above the
+          awning (a lit sign carrying the wall), not floating. */}
+      {[-1, 1].map((side) => (
+        <mesh key={side} position={[side * (BOARD_W / 2 - 0.3), -BOARD_H / 2 - 0.55, -0.02]}>
+          <cylinderGeometry args={[0.035, 0.035, 1.4, 8]} />
+          <meshStandardMaterial color="#241d2c" />
+        </mesh>
+      ))}
+
       {/* The 6×4 grid — newest tile top-left, empty slots keep their frame. */}
       {Array.from({ length: SCENE_TILE_COUNT }, (_, i) => {
         const { x, y } = tileGridPosition(i);

--- a/src/components/three/game/DoodleWall.tsx
+++ b/src/components/three/game/DoodleWall.tsx
@@ -74,7 +74,7 @@ function bulbPositions(): [number, number][] {
 }
 
 /** One approved tile as a textured plane. Until its PNG arrives (or if it never
- *  does) the slot shows the tile-ground colour, same as an empty frame. */
+ *  does) the frame shows the tile-ground colour, same as an empty frame. */
 function TilePlane({
   url,
   geometry,
@@ -107,7 +107,7 @@ function TilePlane({
       },
       undefined,
       () => {
-        /* failed tile → the slot stays as tile-ground; scenery degrades quietly */
+        /* failed tile → its frame stays as tile-ground; scenery degrades quietly */
       },
     );
     return () => {
@@ -144,7 +144,7 @@ export function DoodleWall({ bloomOn = false }: { bloomOn?: boolean }) {
     };
   }, []);
 
-  // Shared geometry + materials for the 24 slots (one program, one plane).
+  // Shared geometry + materials for the 24 grid positions (one program, one plane).
   const shared = useMemo(
     () => ({
       tileGeom: new PlaneGeometry(TILE_SIZE, TILE_SIZE),
@@ -211,7 +211,7 @@ export function DoodleWall({ bloomOn = false }: { bloomOn?: boolean }) {
         </mesh>
       ))}
 
-      {/* The 6×4 grid — newest tile top-left, empty slots keep their frame. */}
+      {/* The 6×4 grid — newest tile top-left; positions without a tile keep an empty frame. */}
       {Array.from({ length: SCENE_TILE_COUNT }, (_, i) => {
         const { x, y } = tileGridPosition(i);
         const tile = tiles[i];

--- a/src/components/three/game/DoodleWall.tsx
+++ b/src/components/three/game/DoodleWall.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useThree } from '@react-three/fiber';
+import {
+  AdditiveBlending,
+  BufferGeometry,
+  Float32BufferAttribute,
+  type InstancedMesh,
+  Matrix4,
+  MeshBasicMaterial,
+  PlaneGeometry,
+  SRGBColorSpace,
+  type Texture,
+  TextureLoader,
+} from 'three';
+
+import { getGlowTexture } from '@/components/three/shared/glowTexture';
+import {
+  BOARD_CENTER,
+  BOARD_DEPTH,
+  BOARD_H,
+  BOARD_W,
+  BOARD_YAW,
+  BULB_COLOR,
+  BULB_INSET,
+  BULB_SPACING,
+  FRAME_LINE,
+  SCENE_TILE_COUNT,
+  TILE_GROUND,
+  TILE_SIZE,
+  tileGridPosition,
+  type WallTile,
+} from './doodleWallConfig';
+
+/**
+ * DoodleWall — the communal stall's board at the end of the Midway: a 6×4 grid
+ * of the newest approved tiles, rendered as textured planes on a flat board
+ * with a thin emissive frame line per tile and a practical bulb string around
+ * the edge (emissive bulbs + the shared additive halo sprites — the same
+ * no-composer glow the rest of the carnival uses).
+ *
+ * This is scenery: always mounted, visible while travelling on Full AND Lite.
+ * The stall prefab itself (SM_Prop_Stall_03) is placed via EXTRA_INSTANCES in
+ * sceneAdditions.ts so it gets the shared-atlas treatment; this component only
+ * adds the board. Drawing happens in the DOM step-in overlay (DoodleWallHud),
+ * never here.
+ *
+ * Tiles come from GET /api/wall; `imageUrl` is a data URI in stub mode and an
+ * https Storage URL once Supabase is live — TextureLoader handles both.
+ */
+
+/** z-offsets off the board face so frame < tile, no z-fighting. */
+const FRAME_Z = BOARD_DEPTH / 2 + 0.004;
+const TILE_Z = BOARD_DEPTH / 2 + 0.008;
+const BULB_Z = BOARD_DEPTH / 2 + 0.03;
+
+/** Bulb centres (local x/y) strung around the board's edge. */
+function bulbPositions(): [number, number][] {
+  const w = BOARD_W / 2 + BULB_INSET;
+  const h = BOARD_H / 2 + BULB_INSET;
+  const nx = Math.max(2, Math.round((2 * w) / BULB_SPACING));
+  const ny = Math.max(2, Math.round((2 * h) / BULB_SPACING));
+  const pts: [number, number][] = [];
+  for (let i = 0; i <= nx; i++) {
+    const x = -w + (2 * w * i) / nx;
+    pts.push([x, h], [x, -h]);
+  }
+  for (let j = 1; j < ny; j++) {
+    const y = -h + (2 * h * j) / ny;
+    pts.push([-w, y], [w, y]);
+  }
+  return pts;
+}
+
+/** One approved tile as a textured plane. Until its PNG arrives (or if it never
+ *  does) the slot shows the tile-ground colour, same as an empty frame. */
+function TilePlane({
+  url,
+  geometry,
+  fallback,
+}: {
+  url: string;
+  geometry: PlaneGeometry;
+  fallback: MeshBasicMaterial;
+}) {
+  const invalidate = useThree((s) => s.invalidate);
+  const [tex, setTex] = useState<Texture | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    let loaded: Texture | null = null;
+    new TextureLoader().load(
+      url,
+      (t) => {
+        if (!live) {
+          t.dispose();
+          return;
+        }
+        // Doodles are colour data → sRGB. Orientation: TextureLoader's default
+        // flipY=true matches PlaneGeometry UVs (verified by headless screenshot;
+        // the GLTF atlas' flipY=false convention does NOT apply here).
+        t.colorSpace = SRGBColorSpace;
+        loaded = t;
+        setTex(t);
+        invalidate(); // Lite runs frameloop='demand' — show the tile when it lands
+      },
+      undefined,
+      () => {
+        /* failed tile → the slot stays as tile-ground; scenery degrades quietly */
+      },
+    );
+    return () => {
+      live = false;
+      loaded?.dispose();
+    };
+  }, [url, invalidate]);
+
+  return (
+    <mesh position={[0, 0, TILE_Z]} geometry={geometry} material={tex ? undefined : fallback}>
+      {/* Unlit: a tile reads like a lit board at night, independent of scene lights. */}
+      {tex && <meshBasicMaterial map={tex} />}
+    </mesh>
+  );
+}
+
+export function DoodleWall({ bloomOn = false }: { bloomOn?: boolean }) {
+  const invalidate = useThree((s) => s.invalidate);
+  const [tiles, setTiles] = useState<WallTile[]>([]);
+
+  // The wall is persisted, not live — one fetch per visit is the contract.
+  useEffect(() => {
+    let live = true;
+    fetch('/api/wall')
+      .then((r) => (r.ok ? (r.json() as Promise<{ tiles: WallTile[] }>) : null))
+      .then((data) => {
+        if (live && data) setTiles(data.tiles.slice(0, SCENE_TILE_COUNT));
+      })
+      .catch(() => {
+        /* offline / API down → empty frames; the stall still reads as scenery */
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  // Shared geometry + materials for the 24 slots (one program, one plane).
+  const shared = useMemo(
+    () => ({
+      tileGeom: new PlaneGeometry(TILE_SIZE, TILE_SIZE),
+      frameGeom: new PlaneGeometry(TILE_SIZE + 2 * FRAME_LINE, TILE_SIZE + 2 * FRAME_LINE),
+      frameMat: new MeshBasicMaterial({ color: '#ffb84d' }),
+      emptyMat: new MeshBasicMaterial({ color: TILE_GROUND }),
+    }),
+    [],
+  );
+  useEffect(
+    () => () => {
+      shared.tileGeom.dispose();
+      shared.frameGeom.dispose();
+      shared.frameMat.dispose();
+      shared.emptyMat.dispose();
+    },
+    [shared],
+  );
+
+  // Practical bulb string: instanced emissive spheres…
+  const bulbs = useMemo(() => bulbPositions(), []);
+  const bulbMesh = useRef<InstancedMesh>(null);
+  useEffect(() => {
+    const m = bulbMesh.current;
+    if (!m) return;
+    const mat = new Matrix4();
+    bulbs.forEach(([x, y], i) => {
+      mat.makeTranslation(x, y, BULB_Z);
+      m.setMatrixAt(i, mat);
+    });
+    m.instanceMatrix.needsUpdate = true;
+    invalidate();
+  }, [bulbs, invalidate]);
+
+  // …plus the shared additive halo sprites (the carnival's fake-bloom system).
+  // Mirrors BulbGlow: with the real composer on, the halos would stack into
+  // extreme HDR values, so composer on ⇒ sprites off.
+  const haloGeom = useMemo(() => {
+    const g = new BufferGeometry();
+    const arr: number[] = [];
+    for (const [x, y] of bulbs) arr.push(x, y, BULB_Z);
+    g.setAttribute('position', new Float32BufferAttribute(arr, 3));
+    return g;
+  }, [bulbs]);
+  useEffect(() => () => haloGeom.dispose(), [haloGeom]);
+
+  return (
+    <group
+      position={[BOARD_CENTER[0], BOARD_CENTER[1], BOARD_CENTER[2]]}
+      rotation={[0, BOARD_YAW, 0]}
+    >
+      {/* The board slab the tiles hang on. */}
+      <mesh>
+        <boxGeometry args={[BOARD_W, BOARD_H, BOARD_DEPTH]} />
+        <meshStandardMaterial color="#2a2333" />
+      </mesh>
+
+      {/* The 6×4 grid — newest tile top-left, empty slots keep their frame. */}
+      {Array.from({ length: SCENE_TILE_COUNT }, (_, i) => {
+        const { x, y } = tileGridPosition(i);
+        const tile = tiles[i];
+        return (
+          <group key={tile ? tile.id : `empty-${i}`} position={[x, y, 0]}>
+            <mesh
+              position={[0, 0, FRAME_Z]}
+              geometry={shared.frameGeom}
+              material={shared.frameMat}
+            />
+            {tile ? (
+              <TilePlane
+                url={tile.imageUrl}
+                geometry={shared.tileGeom}
+                fallback={shared.emptyMat}
+              />
+            ) : (
+              <mesh
+                position={[0, 0, TILE_Z]}
+                geometry={shared.tileGeom}
+                material={shared.emptyMat}
+              />
+            )}
+          </group>
+        );
+      })}
+
+      {/* Practical bulbs around the board. */}
+      <instancedMesh ref={bulbMesh} args={[undefined, undefined, bulbs.length]}>
+        <sphereGeometry args={[0.028, 8, 8]} />
+        <meshBasicMaterial color={BULB_COLOR} toneMapped={false} />
+      </instancedMesh>
+      {!bloomOn && (
+        <points geometry={haloGeom} frustumCulled={false}>
+          <pointsMaterial
+            map={getGlowTexture()}
+            color={BULB_COLOR}
+            size={0.45}
+            sizeAttenuation
+            transparent
+            depthWrite={false}
+            blending={AdditiveBlending}
+            toneMapped={false}
+            opacity={0.85}
+          />
+        </points>
+      )}
+    </group>
+  );
+}

--- a/src/components/three/game/DoodleWall.tsx
+++ b/src/components/three/game/DoodleWall.tsx
@@ -202,14 +202,22 @@ export function DoodleWall({ bloomOn = false }: { bloomOn?: boolean }) {
         <meshStandardMaterial color="#2a2333" />
       </mesh>
 
-      {/* Support poles down into the stall roof — the board rides above the
-          awning (a lit sign carrying the wall), not floating. */}
-      {[-1, 1].map((side) => (
-        <mesh key={side} position={[side * (BOARD_W / 2 - 0.3), -BOARD_H / 2 - 0.55, -0.02]}>
-          <cylinderGeometry args={[0.035, 0.035, 1.4, 8]} />
-          <meshStandardMaterial color="#241d2c" />
-        </mesh>
-      ))}
+      {/* Support poles to the ground — the board is freestanding (no stall
+          prefab), a lit signboard planted at the end of the Midway. Pole
+          length runs from the board's bottom edge into the ground (the small
+          overshoot buries the ends so slopes can't leave them floating). */}
+      {[-1, 1].map((side) => {
+        const poleLen = BOARD_CENTER[1] - BOARD_H / 2 + 0.15;
+        return (
+          <mesh
+            key={side}
+            position={[side * (BOARD_W / 2 - 0.3), -BOARD_H / 2 - poleLen / 2 + 0.05, -0.02]}
+          >
+            <cylinderGeometry args={[0.045, 0.045, poleLen, 8]} />
+            <meshStandardMaterial color="#241d2c" />
+          </mesh>
+        );
+      })}
 
       {/* The 6×4 grid — newest tile top-left; positions without a tile keep an empty frame. */}
       {Array.from({ length: SCENE_TILE_COUNT }, (_, i) => {

--- a/src/components/three/game/doodleWallConfig.test.ts
+++ b/src/components/three/game/doodleWallConfig.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BOARD_H,
+  BOARD_W,
+  BRUSH_SIZES,
+  GRID_COLS,
+  GRID_ROWS,
+  INK_PALETTE,
+  SCENE_TILE_COUNT,
+  TILE_GROUND,
+  TILE_PITCH,
+  tileGridPosition,
+  UNDO_DEPTH,
+} from './doodleWallConfig';
+
+/** The 6×4 in-scene grid — deterministic tile placement on the board. */
+describe('tileGridPosition', () => {
+  it('the grid shape covers exactly the scene tile count (6×4 = 24)', () => {
+    expect(GRID_COLS * GRID_ROWS).toBe(SCENE_TILE_COUNT);
+  });
+
+  it('index 0 (the newest tile) sits top-left', () => {
+    const p = tileGridPosition(0);
+    expect(p.x).toBeLessThan(0);
+    expect(p.y).toBeGreaterThan(0);
+  });
+
+  it('reads row-major like a page: one step right per index, one pitch down per row', () => {
+    const first = tileGridPosition(0);
+    const second = tileGridPosition(1);
+    expect(second.x - first.x).toBeCloseTo(TILE_PITCH);
+    expect(second.y).toBeCloseTo(first.y);
+
+    const nextRow = tileGridPosition(GRID_COLS);
+    expect(nextRow.x).toBeCloseTo(first.x);
+    expect(first.y - nextRow.y).toBeCloseTo(TILE_PITCH);
+  });
+
+  it('centres the full grid on the board origin', () => {
+    let sx = 0;
+    let sy = 0;
+    for (let i = 0; i < SCENE_TILE_COUNT; i++) {
+      const p = tileGridPosition(i);
+      sx += p.x;
+      sy += p.y;
+    }
+    expect(sx).toBeCloseTo(0);
+    expect(sy).toBeCloseTo(0);
+  });
+
+  it('every tile (plus pitch margin) fits inside the board face', () => {
+    for (let i = 0; i < SCENE_TILE_COUNT; i++) {
+      const p = tileGridPosition(i);
+      expect(Math.abs(p.x) + TILE_PITCH / 2).toBeLessThanOrEqual(BOARD_W / 2);
+      expect(Math.abs(p.y) + TILE_PITCH / 2).toBeLessThanOrEqual(BOARD_H / 2);
+    }
+  });
+});
+
+/** The drawing tools fixed in the 2026-07-14 grill session. */
+describe('drawing tools', () => {
+  it('offers exactly six neon inks, all distinct, all valid hex', () => {
+    expect(INK_PALETTE).toHaveLength(6);
+    const hexes = INK_PALETTE.map((i) => i.hex);
+    expect(new Set(hexes).size).toBe(hexes.length);
+    for (const { name, hex } of INK_PALETTE) {
+      expect(hex).toMatch(/^#[0-9a-f]{6}$/);
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('the tile ground is a valid near-black hex', () => {
+    expect(TILE_GROUND).toMatch(/^#[0-9a-f]{6}$/);
+    const [r, g, b] = [1, 3, 5].map((i) => parseInt(TILE_GROUND.slice(i, i + 2), 16));
+    expect((r + g + b) / 3).toBeLessThan(40); // near-black, not just dark
+  });
+
+  it('offers three brush sizes, fine to broad', () => {
+    expect(BRUSH_SIZES).toHaveLength(3);
+    expect([...BRUSH_SIZES]).toEqual([...BRUSH_SIZES].slice().sort((a, b) => a - b));
+    expect(new Set(BRUSH_SIZES).size).toBe(3);
+  });
+
+  it('undo runs twenty steps deep', () => {
+    expect(UNDO_DEPTH).toBe(20);
+  });
+});

--- a/src/components/three/game/doodleWallConfig.ts
+++ b/src/components/three/game/doodleWallConfig.ts
@@ -62,11 +62,11 @@ export const BOARD_DEPTH = 0.06;
 
 /**
  * Board centre in three world space + yaw (radians about Y). The stall prefab
- * sits at three (-4, 33) yaw 135° (sceneAdditions); the board hangs at its back
- * wall, facing SW down the Midway toward the iso camera. Iterated visually via
- * headless screenshots — these two are THE placement knobs.
+ * sits at three (-12.5, 31.5) yaw 135° (sceneAdditions); the board hangs at its
+ * back wall, facing SW down the Midway toward the iso camera. Iterated visually
+ * via headless screenshots — these two are THE placement knobs.
  */
-export const BOARD_CENTER: readonly [number, number, number] = [-3.55, 1.72, 33.45];
+export const BOARD_CENTER: readonly [number, number, number] = [-12.08, 1.72, 31.92];
 /** Yaw so the board's face (+z of its group) points SW, matching the stall. */
 export const BOARD_YAW = -Math.PI * 0.75;
 

--- a/src/components/three/game/doodleWallConfig.ts
+++ b/src/components/three/game/doodleWallConfig.ts
@@ -30,12 +30,10 @@ export {
 };
 
 /** One approved tile as `GET /api/wall` serves it (`imageUrl` is a data URI in
- *  stub mode, an https Storage URL once Supabase is live — handle both). */
-export interface WallTile {
-  id: string;
-  imageUrl: string;
-  createdAt: string;
-}
+ *  stub mode, an https Storage URL once Supabase is live — handle both). The
+ *  shape is owned by the domain layer; re-exported here so overlays and the
+ *  scene name one contract without importing from lib directly. */
+export type { WallTile } from '@/lib/doodle-wall/types';
 
 /* --- In-scene board: a fixed 6×4 grid of the newest approved tiles --- */
 

--- a/src/components/three/game/doodleWallConfig.ts
+++ b/src/components/three/game/doodleWallConfig.ts
@@ -1,0 +1,120 @@
+import {
+  DRAWING_CANVAS_SIZE,
+  SCENE_TILE_COUNT,
+  STORED_TILE_SIZE,
+  SUBMIT_BURST_PER_MINUTE,
+  SUBMIT_DAILY_CAP,
+  TILE_MAX_BYTES,
+  WALL_TILE_COUNT,
+} from '@/lib/doodle-wall/constants';
+
+/**
+ * Doodle-wall tuning config — the stall's board layout and the overlay's
+ * drawing tools, in one three-free module (NO `three` / `@react-three/*`
+ * imports: DoodleWallHud lives in the static bundle and imports this file).
+ *
+ * The server truths below are RE-EXPORTED from `src/lib/doodle-wall/constants.ts`
+ * — never redefined here — so the overlay and the in-scene grid can't drift
+ * from what `/api/tiles` accepts. Everything else is presentation tuning,
+ * fixed in the 2026-07-14 grill session (see doodle-wall-handoff §5).
+ */
+
+export {
+  DRAWING_CANVAS_SIZE,
+  SCENE_TILE_COUNT,
+  STORED_TILE_SIZE,
+  SUBMIT_BURST_PER_MINUTE,
+  SUBMIT_DAILY_CAP,
+  TILE_MAX_BYTES,
+  WALL_TILE_COUNT,
+};
+
+/** One approved tile as `GET /api/wall` serves it (`imageUrl` is a data URI in
+ *  stub mode, an https Storage URL once Supabase is live — handle both). */
+export interface WallTile {
+  id: string;
+  imageUrl: string;
+  createdAt: string;
+}
+
+/* --- In-scene board: a fixed 6×4 grid of the newest approved tiles --- */
+
+/** Grid shape — cols × rows must equal SCENE_TILE_COUNT (asserted in tests). */
+export const GRID_COLS = 6;
+export const GRID_ROWS = 4;
+
+/** Edge of one tile plane on the board (metres). */
+export const TILE_SIZE = 0.38;
+/** Gap between neighbouring tiles (metres). */
+export const TILE_GAP = 0.07;
+/** Centre-to-centre distance between neighbouring tiles. */
+export const TILE_PITCH = TILE_SIZE + TILE_GAP;
+/** Half-width of the emissive frame line drawn around each tile (metres). */
+export const FRAME_LINE = 0.015;
+
+/** Board margin outside the outermost tiles (metres). */
+export const BOARD_MARGIN = 0.16;
+/** Board face dimensions (metres) — the grid plus its margin. */
+export const BOARD_W = GRID_COLS * TILE_PITCH - TILE_GAP + 2 * BOARD_MARGIN;
+export const BOARD_H = GRID_ROWS * TILE_PITCH - TILE_GAP + 2 * BOARD_MARGIN;
+/** Board slab thickness (metres). */
+export const BOARD_DEPTH = 0.06;
+
+/**
+ * Board centre in three world space + yaw (radians about Y). The stall prefab
+ * sits at three (-4, 33) yaw 135° (sceneAdditions); the board hangs at its back
+ * wall, facing SW down the Midway toward the iso camera. Iterated visually via
+ * headless screenshots — these two are THE placement knobs.
+ */
+export const BOARD_CENTER: readonly [number, number, number] = [-3.55, 1.72, 33.45];
+/** Yaw so the board's face (+z of its group) points SW, matching the stall. */
+export const BOARD_YAW = -Math.PI * 0.75;
+
+/** Practical bulb spacing along the board's edge (metres). */
+export const BULB_SPACING = 0.34;
+/** How far outside the board edge the bulb string hangs (metres). */
+export const BULB_INSET = 0.1;
+/** Warm practical-bulb colour (matches the scene's lamp warmth, #ff9a3c family). */
+export const BULB_COLOR = '#ffd9a0';
+
+/**
+ * Local x/y (metres, board plane, y-up) of a tile's centre for its wall index,
+ * row-major from the top-left — index 0 (the newest tile) reads first, like a
+ * page. Deterministic: same index, same spot.
+ */
+export function tileGridPosition(index: number): { x: number; y: number } {
+  const col = index % GRID_COLS;
+  const row = Math.floor(index / GRID_COLS);
+  return {
+    x: (col - (GRID_COLS - 1) / 2) * TILE_PITCH,
+    y: ((GRID_ROWS - 1) / 2 - row) * TILE_PITCH,
+  };
+}
+
+/* --- Drawing overlay: tools fixed by the 2026-07-14 grill session --- */
+
+/** The tile ground every drawing starts from — near-black carnival night. */
+export const TILE_GROUND = '#12101c';
+
+/**
+ * The neon inks — six hues drawn from the scene's established bulb/neon
+ * palette (DynamicLights ride accents + the warm lamp pool + the moon key),
+ * so a tile can only ever glow in colours the carnival already wears.
+ */
+export const INK_PALETTE: readonly { name: string; hex: string }[] = [
+  { name: 'Ferris cyan', hex: '#22d3ee' },
+  { name: 'Carousel pink', hex: '#ff2d6e' },
+  { name: 'Teacup violet', hex: '#b06cff' },
+  { name: 'Chair-swing amber', hex: '#ffb84d' },
+  { name: 'Lamplight ember', hex: '#ff9a3c' },
+  { name: 'Moonlight blue', hex: '#aab6f0' },
+];
+
+/** Brush diameters (px on the 512 drawing canvas): fine / medium / broad. */
+export const BRUSH_SIZES: readonly number[] = [6, 14, 26];
+
+/** How many strokes the visitor can step back through. */
+export const UNDO_DEPTH = 20;
+
+/** Minimum time the submitting state shows, so it never flashes (ms). */
+export const SUBMIT_FEEDBACK_MIN_MS = 450;

--- a/src/components/three/game/doodleWallConfig.ts
+++ b/src/components/three/game/doodleWallConfig.ts
@@ -59,15 +59,19 @@ export const BOARD_H = GRID_ROWS * TILE_PITCH - TILE_GAP + 2 * BOARD_MARGIN;
 export const BOARD_DEPTH = 0.06;
 
 /**
- * Board centre in three world space + yaw (radians about Y). The stall prefab
- * sits at three (12.5, 36.8) yaw 135° (sceneAdditions); the board rides ABOVE
- * the stall's roofline like a big lit sign (the awning hides anything lower
- * from the iso camera), facing SW down the Midway. Iterated visually via
- * headless screenshots — these two are THE placement knobs.
+ * Board centre in three world space + yaw (radians about Y). The board is
+ * FREESTANDING (no stall prefab — Nick, 2026-07-14): a lit signboard on two
+ * poles in the NE fence corner at the end of the Midway. The first spot,
+ * (12.5, 36.8), sat inside the big tree canopy there (SM_Env_Leaves_01 at
+ * three ≈(11.6, 35.4)) and read as "inside a tent" — this corner is the
+ * clearest ground past the big top (verified against demo-instances).
+ * Standing height: the bottom edge clears the ground by ~1 m so the whole
+ * grid reads from the iso camera. Iterated visually via headless
+ * screenshots — these two are THE placement knobs.
  */
-export const BOARD_CENTER: readonly [number, number, number] = [12.5, 3.35, 36.8];
-/** Yaw so the board's face (+z of its group) points SW, matching the stall. */
-export const BOARD_YAW = -Math.PI * 0.75;
+export const BOARD_CENTER: readonly [number, number, number] = [17.5, 2.0, 39.0];
+/** Yaw so the board's face (+z of its group) points S-SW, back down the street. */
+export const BOARD_YAW = -Math.PI + 0.2;
 
 /** Practical bulb spacing along the board's edge (metres). */
 export const BULB_SPACING = 0.34;

--- a/src/components/three/game/doodleWallConfig.ts
+++ b/src/components/three/game/doodleWallConfig.ts
@@ -62,11 +62,12 @@ export const BOARD_DEPTH = 0.06;
 
 /**
  * Board centre in three world space + yaw (radians about Y). The stall prefab
- * sits at three (-12.5, 31.5) yaw 135° (sceneAdditions); the board hangs at its
- * back wall, facing SW down the Midway toward the iso camera. Iterated visually
- * via headless screenshots — these two are THE placement knobs.
+ * sits at three (12.5, 36.8) yaw 135° (sceneAdditions); the board rides ABOVE
+ * the stall's roofline like a big lit sign (the awning hides anything lower
+ * from the iso camera), facing SW down the Midway. Iterated visually via
+ * headless screenshots — these two are THE placement knobs.
  */
-export const BOARD_CENTER: readonly [number, number, number] = [-12.08, 1.72, 31.92];
+export const BOARD_CENTER: readonly [number, number, number] = [12.5, 3.35, 36.8];
 /** Yaw so the board's face (+z of its group) points SW, matching the stall. */
 export const BOARD_YAW = -Math.PI * 0.75;
 

--- a/src/components/three/synty/attractions.ts
+++ b/src/components/three/synty/attractions.ts
@@ -129,16 +129,20 @@ export const ATTRACTIONS: Attraction[] = [
     // The communal doodle wall at the end of the Midway (past contact, per
     // CONTEXT.md's order) — a stall variant distinct from ball-toss's Stall_02.
     // The focus target is the tile board's centre (drawn by <DoodleWall> at
-    // doodleWallConfig.BOARD_CENTER); the camera stands on the board's SW
-    // normal, close enough that the ~2.9 m board fills the view (fov 34° →
-    // 0.61·d vertical: d ≈ 4.5 shows the 2 m board plus the stall's roofline).
+    // doodleWallConfig.BOARD_CENTER, riding above the stall roofline so the
+    // awning can't hide it), far enough back that the ~2.9 × 2 m board plus
+    // its bulb string fills the view (fov 34° → 0.61·d vertical: d ≈ 6.5).
+    // Dead-on from the board's SW normal the camera clips the big top's roof
+    // edge, so the facing is swung ~30° south to approach through the gap
+    // between the big top and the barricades (same trick as the fortune
+    // wagon). Verified by headless screenshot.
     id: 'doodle-wall',
     title: 'Doodle Wall',
     section: 'game:doodle-wall',
     prefab: 'SM_Prop_Stall_03',
-    transform: [-12.5, 0.1, -31.5, 0, 0.92388, 0, 0.38268, 1, 1, 1],
-    position: [-12.08, 1.72, 31.92],
-    facing: [-0.707, 0, -0.707],
-    focusDist: 4.5,
+    transform: [12.5, 0.1, -36.8, 0, 0.92388, 0, 0.38268, 1, 1, 1],
+    position: [12.5, 3.35, 36.8],
+    facing: [-0.35, 0, -0.94],
+    focusDist: 6.5,
   },
 ];

--- a/src/components/three/synty/attractions.ts
+++ b/src/components/three/synty/attractions.ts
@@ -125,4 +125,20 @@ export const ATTRACTIONS: Attraction[] = [
     facing: [-0.707, 0, 0.707],
     focusDist: 5.2,
   },
+  {
+    // The communal doodle wall at the end of the Midway (past contact, per
+    // CONTEXT.md's order) — a stall variant distinct from ball-toss's Stall_02.
+    // The focus target is the tile board's centre (drawn by <DoodleWall> at
+    // doodleWallConfig.BOARD_CENTER); the camera stands on the board's SW
+    // normal, close enough that the ~2.9 m board fills the view (fov 34° →
+    // 0.61·d vertical: d ≈ 4.5 shows the 2 m board plus the stall's roofline).
+    id: 'doodle-wall',
+    title: 'Doodle Wall',
+    section: 'game:doodle-wall',
+    prefab: 'SM_Prop_Stall_03',
+    transform: [-12.5, 0.1, -31.5, 0, 0.92388, 0, 0.38268, 1, 1, 1],
+    position: [-12.08, 1.72, 31.92],
+    facing: [-0.707, 0, -0.707],
+    focusDist: 4.5,
+  },
 ];

--- a/src/components/three/synty/attractions.ts
+++ b/src/components/three/synty/attractions.ts
@@ -11,8 +11,9 @@ export interface Attraction {
   id: string;
   title: string;
   section: string;
-  /** GLB key of the structure (for an optional focus highlight). */
-  prefab: string;
+  /** GLB key of the structure (for an optional focus highlight). Absent for
+   *  attractions drawn by our own components (the doodle wall board). */
+  prefab?: string;
   /** Unity TRS [px,py,pz, qx,qy,qz,qw, sx,sy,sz] of the instance. */
   transform: number[];
   /** World centre — indicator anchor + camera focus target. */
@@ -127,22 +128,21 @@ export const ATTRACTIONS: Attraction[] = [
   },
   {
     // The communal doodle wall at the end of the Midway (past contact, per
-    // CONTEXT.md's order) — a stall variant distinct from ball-toss's Stall_02.
-    // The focus target is the tile board's centre (drawn by <DoodleWall> at
-    // doodleWallConfig.BOARD_CENTER, riding above the stall roofline so the
-    // awning can't hide it), far enough back that the ~2.9 × 2 m board plus
-    // its bulb string fills the view (fov 34° → 0.61·d vertical: d ≈ 6.5).
-    // Dead-on from the board's SW normal the camera clips the big top's roof
-    // edge, so the facing is swung ~30° south to approach through the gap
-    // between the big top and the barricades (same trick as the fortune
-    // wagon). Verified by headless screenshot.
+    // CONTEXT.md's order) — a FREESTANDING bulb-strung tile board on poles
+    // in the NE fence corner, drawn entirely by <DoodleWall> (no stall
+    // prefab; the first placement sat inside the big tree canopy there —
+    // Nick, 2026-07-14). The focus target is the board's centre
+    // (doodleWallConfig.BOARD_CENTER), far enough back that the ~2.9 × 2 m
+    // board plus its bulb string fills the view (fov 34° → 0.61·d vertical:
+    // d ≈ 5.5). The facing is swung south of the board's normal so the
+    // camera approaches through the gap between the tree and the fence
+    // rather than through the canopy.
     id: 'doodle-wall',
     title: 'Doodle Wall',
     section: 'game:doodle-wall',
-    prefab: 'SM_Prop_Stall_03',
-    transform: [12.5, 0.1, -36.8, 0, 0.92388, 0, 0.38268, 1, 1, 1],
-    position: [12.5, 3.35, 36.8],
-    facing: [-0.35, 0, -0.94],
-    focusDist: 6.5,
+    transform: [17.5, 0.1, -39.0, 0, 0.995, 0, -0.0998, 1, 1, 1],
+    position: [17.5, 2.0, 39.0],
+    facing: [-0.2, 0, -0.98],
+    focusDist: 5.5,
   },
 ];

--- a/src/components/three/synty/sceneAdditions.ts
+++ b/src/components/three/synty/sceneAdditions.ts
@@ -41,11 +41,12 @@ export const EXTRA_INSTANCES: Record<string, number[][]> = {
   SM_Prop_Lamp_Post_02: EXTRA_LAMPS.map(([x, z, yaw]) => at(x, z, yaw ?? 0)),
   // the Ball Toss booth — a stall (facing SW, toward the iso camera) in an open spot
   SM_Prop_Stall_02: [at(13, -12, 45, 0.1)],
-  // the doodle wall's stall — the end of the Midway (past contact / the ferris
-  // wheel), on the grass beside the north dirt road, board facing SW toward the
+  // the doodle wall's stall — the end of the Midway, on the grass at the
+  // north-east fence line (past the big top), facing SW back down the street at
   // iso camera. A distinct variant from ball-toss's Stall_02. The tile board
-  // itself is drawn by <DoodleWall> (doodleWallConfig.BOARD_CENTER tracks this).
-  SM_Prop_Stall_03: [at(-12.5, 31.5, 135, 0.1)],
+  // itself is drawn by <DoodleWall> riding above the roofline
+  // (doodleWallConfig.BOARD_CENTER tracks this position).
+  SM_Prop_Stall_03: [at(12.5, 36.8, 135, 0.1)],
   // NB no separate milk-bottle rack: the game's bottle pyramid rests directly on
   // the stall counter (ballTossConfig.STACK_ANCHOR). The rack prop used to float
   // at y=1.0 behind the counter reading as "a random table in the air".

--- a/src/components/three/synty/sceneAdditions.ts
+++ b/src/components/three/synty/sceneAdditions.ts
@@ -41,6 +41,11 @@ export const EXTRA_INSTANCES: Record<string, number[][]> = {
   SM_Prop_Lamp_Post_02: EXTRA_LAMPS.map(([x, z, yaw]) => at(x, z, yaw ?? 0)),
   // the Ball Toss booth — a stall (facing SW, toward the iso camera) in an open spot
   SM_Prop_Stall_02: [at(13, -12, 45, 0.1)],
+  // the doodle wall's stall — the end of the Midway (past contact / the ferris
+  // wheel), on the grass beside the north dirt road, board facing SW toward the
+  // iso camera. A distinct variant from ball-toss's Stall_02. The tile board
+  // itself is drawn by <DoodleWall> (doodleWallConfig.BOARD_CENTER tracks this).
+  SM_Prop_Stall_03: [at(-12.5, 31.5, 135, 0.1)],
   // NB no separate milk-bottle rack: the game's bottle pyramid rests directly on
   // the stall counter (ballTossConfig.STACK_ANCHOR). The rack prop used to float
   // at y=1.0 behind the counter reading as "a random table in the air".

--- a/src/components/three/synty/sceneAdditions.ts
+++ b/src/components/three/synty/sceneAdditions.ts
@@ -41,12 +41,10 @@ export const EXTRA_INSTANCES: Record<string, number[][]> = {
   SM_Prop_Lamp_Post_02: EXTRA_LAMPS.map(([x, z, yaw]) => at(x, z, yaw ?? 0)),
   // the Ball Toss booth — a stall (facing SW, toward the iso camera) in an open spot
   SM_Prop_Stall_02: [at(13, -12, 45, 0.1)],
-  // the doodle wall's stall — the end of the Midway, on the grass at the
-  // north-east fence line (past the big top), facing SW back down the street at
-  // iso camera. A distinct variant from ball-toss's Stall_02. The tile board
-  // itself is drawn by <DoodleWall> riding above the roofline
-  // (doodleWallConfig.BOARD_CENTER tracks this position).
-  SM_Prop_Stall_03: [at(12.5, 36.8, 135, 0.1)],
+  // NB the doodle wall has no stall prefab (Nick, 2026-07-14 — the Stall_03
+  // placed here first landed inside an existing tent): the freestanding
+  // bulb-strung tile board is drawn entirely by <DoodleWall> at
+  // doodleWallConfig.BOARD_CENTER.
   // NB no separate milk-bottle rack: the game's bottle pyramid rests directly on
   // the stall counter (ballTossConfig.STACK_ANCHOR). The rack prop used to float
   // at y=1.0 behind the counter reading as "a random table in the air".

--- a/src/lib/doodle-wall/constants.ts
+++ b/src/lib/doodle-wall/constants.ts
@@ -9,7 +9,7 @@
  * until the scene/overlay slice lands; knip noise on them is expected.
  */
 
-/** Stored tile PNGs are exactly this many pixels square. */
+/** Stored tile PNGs are exactly STORED_TILE_SIZE × STORED_TILE_SIZE pixels. */
 export const STORED_TILE_SIZE = 256;
 
 /** The drawing overlay's canvas edge — draws at 512, exports at 256. */

--- a/src/lib/doodle-wall/constants.ts
+++ b/src/lib/doodle-wall/constants.ts
@@ -1,0 +1,31 @@
+/**
+ * Doodle wall server truths — the single source for both sides of the app.
+ * The API routes and tileService enforce these; the scene/overlay slice reads
+ * the same values so the drawing overlay and the in-scene grid can never
+ * drift from what the server accepts. All numbers were fixed in the
+ * 2026-07-14 grill session (ADR-0001) — do not retune here.
+ *
+ * Some constants (DRAWING_CANVAS_SIZE, SCENE_TILE_COUNT) have no consumer
+ * until the scene/overlay slice lands; knip noise on them is expected.
+ */
+
+/** Stored tile PNGs are exactly this many pixels square. */
+export const STORED_TILE_SIZE = 256;
+
+/** The drawing overlay's canvas edge — draws at 512, exports at 256. */
+export const DRAWING_CANVAS_SIZE = 512;
+
+/** Byte ceiling for a stored tile PNG (128 KB). */
+export const TILE_MAX_BYTES = 131_072;
+
+/** Upper bound on tiles returned by the wall query (GET /api/wall). */
+export const WALL_TILE_COUNT = 48;
+
+/** The in-scene grid renders the newest tiles in a fixed 6×4. */
+export const SCENE_TILE_COUNT = 24;
+
+/** Burst guard: submissions allowed per IP per minute (in-memory). */
+export const SUBMIT_BURST_PER_MINUTE = 2;
+
+/** Daily cap: submissions per submitter hash per rolling 24 h (durable). */
+export const SUBMIT_DAILY_CAP = 10;

--- a/src/lib/doodle-wall/constants.ts
+++ b/src/lib/doodle-wall/constants.ts
@@ -5,8 +5,10 @@
  * drift from what the server accepts. All numbers were fixed in the
  * 2026-07-14 grill session (ADR-0001) — do not retune here.
  *
- * Some constants (DRAWING_CANVAS_SIZE, SCENE_TILE_COUNT) have no consumer
- * until the scene/overlay slice lands; knip noise on them is expected.
+ * The migration (supabase/migrations/…_doodle_wall.sql) hard-codes two of
+ * these where SQL cannot import TS: the bucket file_size_limit mirrors
+ * TILE_MAX_BYTES and the status check mirrors TileStatus — retuning either
+ * needs a migration too.
  */
 
 /** Stored tile PNGs are exactly STORED_TILE_SIZE × STORED_TILE_SIZE pixels. */

--- a/src/lib/doodle-wall/fakes.ts
+++ b/src/lib/doodle-wall/fakes.ts
@@ -1,0 +1,189 @@
+import { Buffer } from 'node:buffer';
+import { randomUUID } from 'node:crypto';
+import { deflateSync } from 'node:zlib';
+
+import { STORED_TILE_SIZE } from './constants';
+import type { TileImageStore, TileRepository } from './ports';
+import type { Tile } from './types';
+
+/**
+ * In-memory adapters for the doodle wall ports — what dev, CI, and a
+ * keyless production run against (stub mode) until Nick provisions
+ * Supabase. Also includes a tiny programmatic PNG builder so the seeded
+ * wall serves real, renderable 256×256 PNGs as data URIs and the tests can
+ * mint valid (and deliberately invalid) fixtures without binary files.
+ */
+
+// --- PNG builder -----------------------------------------------------------
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Uint8Array): Uint8Array {
+  const out = new Uint8Array(12 + data.length);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, data.length);
+  for (let i = 0; i < 4; i++) out[4 + i] = type.charCodeAt(i);
+  out.set(data, 8);
+  view.setUint32(8 + data.length, crc32(out.subarray(4, 8 + data.length)));
+  return out;
+}
+
+export type Rgb = readonly [number, number, number];
+
+/** Build a valid truecolour PNG of `size`×`size`, one callback per pixel. */
+export function makeTilePng(size: number, pixelAt: (x: number, y: number) => Rgb): Uint8Array {
+  const signature = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+  const ihdr = new Uint8Array(13);
+  const ihdrView = new DataView(ihdr.buffer);
+  ihdrView.setUint32(0, size); // width
+  ihdrView.setUint32(4, size); // height
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // colour type: truecolour
+  // compression, filter, interlace all 0
+
+  // Raw scanlines: one filter byte (0 = none) then RGB triples.
+  const raw = new Uint8Array(size * (1 + size * 3));
+  for (let y = 0; y < size; y++) {
+    const row = y * (1 + size * 3);
+    for (let x = 0; x < size; x++) {
+      const [r, g, b] = pixelAt(x, y);
+      raw[row + 1 + x * 3] = r;
+      raw[row + 2 + x * 3] = g;
+      raw[row + 3 + x * 3] = b;
+    }
+  }
+
+  const idat = pngChunk('IDAT', new Uint8Array(deflateSync(raw)));
+  const chunks = [signature, pngChunk('IHDR', ihdr), idat, pngChunk('IEND', new Uint8Array(0))];
+  const png = new Uint8Array(chunks.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of chunks) {
+    png.set(part, offset);
+    offset += part.length;
+  }
+  return png;
+}
+
+/** A single-colour PNG — compresses to a few hundred bytes. */
+export function makeSolidPng(size: number, colour: Rgb): Uint8Array {
+  return makeTilePng(size, () => colour);
+}
+
+/**
+ * A valid PNG of pseudo-random pixels — incompressible, so at 256×256 it
+ * lands well over TILE_MAX_BYTES. Deterministic (LCG), no I/O.
+ */
+export function makeNoisePng(size: number): Uint8Array {
+  // xorshift32 — an LCG's low bits are periodic enough for deflate to crush.
+  let state = 0x2f6e2b1;
+  const next = () => {
+    state ^= state << 13;
+    state >>>= 0;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    return state & 0xff;
+  };
+  return makeTilePng(size, () => [next(), next(), next()]);
+}
+
+function pngDataUri(bytes: Uint8Array): string {
+  return `data:image/png;base64,${Buffer.from(bytes).toString('base64')}`;
+}
+
+// --- Seed data --------------------------------------------------------------
+
+/** Neon-ish carnival palette for the seeded stub wall. */
+const SEED_PALETTE: readonly Rgb[] = [
+  [255, 64, 129],
+  [64, 196, 255],
+  [255, 196, 0],
+  [124, 77, 255],
+  [0, 230, 118],
+  [255, 110, 64],
+  [24, 255, 255],
+  [244, 143, 177],
+];
+
+const SEED_BASE_MS = Date.parse('2026-07-01T12:00:00.000Z');
+
+/**
+ * Deterministic approved tiles so GET /api/wall returns renderable stub
+ * data before Supabase exists — the scene slice builds against this. Index
+ * 23 is the newest.
+ */
+export function seedApprovedTiles(): Tile[] {
+  return Array.from({ length: 24 }, (_, i) => {
+    const index = String(i + 1).padStart(2, '0');
+    const bytes = makeSolidPng(STORED_TILE_SIZE, SEED_PALETTE[i % SEED_PALETTE.length]);
+    return {
+      id: `seed-tile-${index}`,
+      imagePath: `seed/seed-tile-${index}.png`,
+      imageUrl: pngDataUri(bytes),
+      status: 'approved' as const,
+      submitterHash: 'seed',
+      createdAt: new Date(SEED_BASE_MS + i * 60_000).toISOString(),
+    };
+  });
+}
+
+// --- Port fakes --------------------------------------------------------------
+
+export class InMemoryTileRepository implements TileRepository {
+  private tiles: Tile[];
+
+  constructor(seed: Tile[] = []) {
+    this.tiles = [...seed];
+  }
+
+  insert(tile: Tile): Promise<void> {
+    this.tiles.push(tile);
+    return Promise.resolve();
+  }
+
+  recentApproved(limit: number): Promise<Tile[]> {
+    const approved = this.tiles
+      .filter((tile) => tile.status === 'approved')
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, limit);
+    return Promise.resolve(approved);
+  }
+
+  countSubmittedSince(submitterHash: string, sinceIso: string): Promise<number> {
+    const count = this.tiles.filter(
+      (tile) => tile.submitterHash === submitterHash && tile.createdAt >= sinceIso,
+    ).length;
+    return Promise.resolve(count);
+  }
+
+  /** Test/stub inspection — deliberately not part of the port. */
+  all(): readonly Tile[] {
+    return this.tiles;
+  }
+}
+
+export class InMemoryTileImageStore implements TileImageStore {
+  private images = new Map<string, Uint8Array>();
+
+  store(bytes: Uint8Array): Promise<{ path: string; url: string }> {
+    const path = `${randomUUID()}.png`;
+    this.images.set(path, bytes);
+    // A data URI stands in for the Storage public URL — renderable anywhere.
+    return Promise.resolve({ path, url: pngDataUri(bytes) });
+  }
+}

--- a/src/lib/doodle-wall/fakes.ts
+++ b/src/lib/doodle-wall/fakes.ts
@@ -186,4 +186,9 @@ export class InMemoryTileImageStore implements TileImageStore {
     // A data URI stands in for the Storage public URL — renderable anywhere.
     return Promise.resolve({ path, url: pngDataUri(bytes) });
   }
+
+  remove(path: string): Promise<void> {
+    this.images.delete(path);
+    return Promise.resolve();
+  }
 }

--- a/src/lib/doodle-wall/png.test.ts
+++ b/src/lib/doodle-wall/png.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeNoisePng, makeSolidPng } from './fakes';
+import { readPngDimensions } from './png';
+
+describe('readPngDimensions', () => {
+  it('reads the dimensions of a valid PNG', () => {
+    expect(readPngDimensions(makeSolidPng(256, [255, 64, 129]))).toEqual({
+      width: 256,
+      height: 256,
+    });
+    expect(readPngDimensions(makeSolidPng(512, [0, 0, 0]))).toEqual({ width: 512, height: 512 });
+  });
+
+  it('reads noise PNGs the same as solid ones', () => {
+    expect(readPngDimensions(makeNoisePng(256))).toEqual({ width: 256, height: 256 });
+  });
+
+  it('rejects bytes without the PNG signature', () => {
+    expect(readPngDimensions(new TextEncoder().encode('<svg xmlns="…"></svg> padding padding'))) //
+      .toBeNull();
+    const almost = makeSolidPng(256, [1, 2, 3]);
+    almost[0] = 0x88;
+    expect(readPngDimensions(almost)).toBeNull();
+  });
+
+  it('rejects truncated buffers', () => {
+    expect(readPngDimensions(new Uint8Array(0))).toBeNull();
+    expect(readPngDimensions(makeSolidPng(256, [1, 2, 3]).slice(0, 20))).toBeNull();
+  });
+
+  it('rejects a PNG whose first chunk is not a well-formed IHDR', () => {
+    const png = makeSolidPng(256, [1, 2, 3]);
+    const badLength = png.slice();
+    badLength[11] = 14; // IHDR length must be exactly 13
+    expect(readPngDimensions(badLength)).toBeNull();
+    const badType = png.slice();
+    badType[12] = 0x4a; // "JHDR"
+    expect(readPngDimensions(badType)).toBeNull();
+  });
+
+  it('rejects zero-sized dimensions', () => {
+    const png = makeSolidPng(256, [1, 2, 3]);
+    png[16] = png[17] = png[18] = png[19] = 0; // width = 0
+    expect(readPngDimensions(png)).toBeNull();
+  });
+
+  it('is offset-safe when handed a subarray view', () => {
+    const png = makeSolidPng(256, [9, 9, 9]);
+    const padded = new Uint8Array(png.length + 8);
+    padded.set(png, 8);
+    expect(readPngDimensions(padded.subarray(8))).toEqual({ width: 256, height: 256 });
+  });
+});

--- a/src/lib/doodle-wall/png.ts
+++ b/src/lib/doodle-wall/png.ts
@@ -1,0 +1,34 @@
+/**
+ * Minimal PNG header validation for untrusted tile submissions. Hand-parses
+ * the fixed-layout signature + IHDR chunk from the raw bytes — no image
+ * library, nothing is decoded, and non-PNG payloads (SVG especially) can
+ * never pass because only the exact 8-byte PNG signature is accepted.
+ *
+ * Layout (PNG spec, RFC 2083): bytes 0–7 signature; bytes 8–11 IHDR length
+ * (always 13); bytes 12–15 the ASCII type "IHDR"; bytes 16–19 width and
+ * 20–23 height, both big-endian uint32.
+ */
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** Signature + IHDR length/type + width + height. */
+const MIN_HEADER_BYTES = 24;
+
+const IHDR_TYPE = [0x49, 0x48, 0x44, 0x52]; // "IHDR"
+
+/**
+ * Read the pixel dimensions of a PNG buffer, or null when the bytes are not
+ * a well-formed PNG header (wrong signature, truncated, IHDR not first).
+ */
+export function readPngDimensions(bytes: Uint8Array): { width: number; height: number } | null {
+  if (bytes.length < MIN_HEADER_BYTES) return null;
+  if (PNG_SIGNATURE.some((byte, i) => bytes[i] !== byte)) return null;
+  // IHDR must be the first chunk, with its spec-fixed 13-byte length.
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (view.getUint32(8) !== 13) return null;
+  if (IHDR_TYPE.some((byte, i) => bytes[12 + i] !== byte)) return null;
+  const width = view.getUint32(16);
+  const height = view.getUint32(20);
+  if (width === 0 || height === 0) return null;
+  return { width, height };
+}

--- a/src/lib/doodle-wall/ports.ts
+++ b/src/lib/doodle-wall/ports.ts
@@ -22,4 +22,9 @@ export interface TileRepository {
 export interface TileImageStore {
   /** Persist validated PNG bytes; returns the storage path + public URL. */
   store(bytes: Uint8Array): Promise<{ path: string; url: string }>;
+  /**
+   * Delete a stored image — the compensation path when the row insert fails
+   * after the upload, so the bucket never accretes PNGs no row references.
+   */
+  remove(path: string): Promise<void>;
 }

--- a/src/lib/doodle-wall/ports.ts
+++ b/src/lib/doodle-wall/ports.ts
@@ -1,0 +1,25 @@
+import type { Tile } from './types';
+
+/**
+ * Ports the tileService depends on — one interface per dependency direction.
+ * Implemented in-memory by ./fakes.ts (dev, CI, keyless production) and by
+ * src/lib/supabase/ once Nick provisions the project. The service never
+ * knows which one it holds.
+ */
+
+export interface TileRepository {
+  insert(tile: Tile): Promise<void>;
+  /** Most-recent approved tiles, newest first, at most `limit`. */
+  recentApproved(limit: number): Promise<Tile[]>;
+  /**
+   * Rows for a submitter hash created at or after `sinceIso` — the durable
+   * daily-cap count, counted through the store so it survives serverless
+   * instance churn.
+   */
+  countSubmittedSince(submitterHash: string, sinceIso: string): Promise<number>;
+}
+
+export interface TileImageStore {
+  /** Persist validated PNG bytes; returns the storage path + public URL. */
+  store(bytes: Uint8Array): Promise<{ path: string; url: string }>;
+}

--- a/src/lib/doodle-wall/submitterHash.test.ts
+++ b/src/lib/doodle-wall/submitterHash.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { hashSubmitter } from './submitterHash';
+
+describe('hashSubmitter', () => {
+  it('is stable for the same IP and secret', () => {
+    expect(hashSubmitter('203.0.113.7', 's3cret')).toBe(hashSubmitter('203.0.113.7', 's3cret'));
+  });
+
+  it('produces lowercase hex of HMAC-SHA256 length', () => {
+    expect(hashSubmitter('203.0.113.7', 's3cret')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('differs across IPs and across secrets', () => {
+    const hash = hashSubmitter('203.0.113.7', 's3cret');
+    expect(hashSubmitter('203.0.113.8', 's3cret')).not.toBe(hash);
+    expect(hashSubmitter('203.0.113.7', 'other')).not.toBe(hash);
+  });
+
+  it('never contains the raw IP', () => {
+    expect(hashSubmitter('203.0.113.7', 's3cret')).not.toContain('203.0.113.7');
+  });
+});

--- a/src/lib/doodle-wall/submitterHash.ts
+++ b/src/lib/doodle-wall/submitterHash.ts
@@ -1,0 +1,11 @@
+import { createHmac } from 'node:crypto';
+
+/**
+ * Stable pseudonym for a submitting IP: HMAC-SHA256(ip) under a server-side
+ * secret, hex-encoded. Stable per IP so the daily cap and abuse tracing
+ * work, but no raw IP is ever at rest — and without the secret the hash
+ * cannot be reversed to an address by dictionary walk.
+ */
+export function hashSubmitter(ip: string, secret: string): string {
+  return createHmac('sha256', secret).update(ip).digest('hex');
+}

--- a/src/lib/doodle-wall/tileService.test.ts
+++ b/src/lib/doodle-wall/tileService.test.ts
@@ -100,13 +100,17 @@ describe('tileService.submitTile — daily cap', () => {
 });
 
 describe('tileService.getWall', () => {
-  it('returns only approved tiles, newest first', async () => {
+  it('returns only approved tiles, newest first, projected to public fields', async () => {
     repository = new InMemoryTileRepository(seedApprovedTiles());
     service = createTileService({ repository, imageStore: new InMemoryTileImageStore() });
     await submit(); // pending — must never surface
     const wall = await service.getWall();
     expect(wall).toHaveLength(seedApprovedTiles().length);
-    expect(wall.every((tile) => tile.status === 'approved')).toBe(true);
+    // The projection happens at the domain boundary: no status, and — the
+    // fields that must never leave the server — no submitterHash, no imagePath.
+    for (const tile of wall) {
+      expect(Object.keys(tile).sort()).toEqual(['createdAt', 'id', 'imageUrl']);
+    }
     const createdAts = wall.map((tile) => tile.createdAt);
     expect(createdAts).toEqual([...createdAts].sort().reverse());
   });

--- a/src/lib/doodle-wall/tileService.test.ts
+++ b/src/lib/doodle-wall/tileService.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { SUBMIT_DAILY_CAP, TILE_MAX_BYTES, WALL_TILE_COUNT } from './constants';
+import {
+  InMemoryTileImageStore,
+  InMemoryTileRepository,
+  makeNoisePng,
+  makeSolidPng,
+  seedApprovedTiles,
+} from './fakes';
+import { createTileService, type TileService } from './tileService';
+import type { Tile } from './types';
+
+/** Service tests run against the in-memory fakes only — no HTTP, no network. */
+
+const VALID_PNG = makeSolidPng(256, [255, 64, 129]);
+const HASH = 'a'.repeat(64);
+
+let repository: InMemoryTileRepository;
+let service: TileService;
+
+beforeEach(() => {
+  repository = new InMemoryTileRepository();
+  service = createTileService({ repository, imageStore: new InMemoryTileImageStore() });
+});
+
+const submit = (imageBytes: Uint8Array = VALID_PNG, submitterHash = HASH) =>
+  service.submitTile({ imageBytes, submitterHash });
+
+describe('tileService.submitTile — validation', () => {
+  it('accepts a valid 256×256 PNG and stores path + url', async () => {
+    const result = await submit();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.tile.imagePath).toMatch(/\.png$/);
+    expect(result.tile.imageUrl).toMatch(/^data:image\/png;base64,/);
+    expect(result.tile.submitterHash).toBe(HASH);
+  });
+
+  it('rejects non-PNG bytes as invalid-image', async () => {
+    const result = await submit(new TextEncoder().encode('<svg/>'.padEnd(64, ' ')));
+    expect(result).toEqual({ ok: false, reason: 'invalid-image' });
+    expect(repository.all()).toHaveLength(0);
+  });
+
+  it('rejects a PNG that is not exactly 256×256', async () => {
+    expect(await submit(makeSolidPng(512, [0, 0, 0]))).toEqual({
+      ok: false,
+      reason: 'invalid-image',
+    });
+    expect(await submit(makeSolidPng(255, [0, 0, 0]))).toEqual({
+      ok: false,
+      reason: 'invalid-image',
+    });
+  });
+
+  it('rejects bytes over the cap as too-large, before any parsing', async () => {
+    const oversized = makeNoisePng(256);
+    expect(oversized.byteLength).toBeGreaterThan(TILE_MAX_BYTES);
+    expect(await submit(oversized)).toEqual({ ok: false, reason: 'too-large' });
+    expect(repository.all()).toHaveLength(0);
+  });
+});
+
+describe('tileService.submitTile — pending is forced', () => {
+  it('stores every accepted tile as pending', async () => {
+    const result = await submit();
+    expect(result.ok && result.tile.status === 'pending').toBe(true);
+    expect(repository.all()[0].status).toBe('pending');
+  });
+
+  it('ignores a smuggled approved status from the caller', async () => {
+    // The input type has no status field; a hostile caller forcing one
+    // through must still land in the pre-moderation queue.
+    const smuggled = { imageBytes: VALID_PNG, submitterHash: HASH, status: 'approved' };
+    const result = await service.submitTile(smuggled as never);
+    expect(result.ok).toBe(true);
+    expect(repository.all()[0].status).toBe('pending');
+    expect(await service.getWall()).toHaveLength(0);
+  });
+});
+
+describe('tileService.submitTile — daily cap', () => {
+  it(`rejects the ${SUBMIT_DAILY_CAP + 1}th same-hash submission inside 24 h`, async () => {
+    for (let i = 0; i < SUBMIT_DAILY_CAP; i++) {
+      expect((await submit()).ok).toBe(true);
+    }
+    expect(await submit()).toEqual({ ok: false, reason: 'daily-cap' });
+    // A different submitter is unaffected.
+    expect((await submit(VALID_PNG, 'b'.repeat(64))).ok).toBe(true);
+  });
+
+  it('accepts again once the 24 h window rolls past old submissions', async () => {
+    const staleIso = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    for (let i = 0; i < SUBMIT_DAILY_CAP; i++) {
+      await repository.insert(makeStoredTile({ submitterHash: HASH, createdAt: staleIso }));
+    }
+    expect((await submit()).ok).toBe(true);
+  });
+});
+
+describe('tileService.getWall', () => {
+  it('returns only approved tiles, newest first', async () => {
+    repository = new InMemoryTileRepository(seedApprovedTiles());
+    service = createTileService({ repository, imageStore: new InMemoryTileImageStore() });
+    await submit(); // pending — must never surface
+    const wall = await service.getWall();
+    expect(wall).toHaveLength(seedApprovedTiles().length);
+    expect(wall.every((tile) => tile.status === 'approved')).toBe(true);
+    const createdAts = wall.map((tile) => tile.createdAt);
+    expect(createdAts).toEqual([...createdAts].sort().reverse());
+  });
+
+  it(`is bounded at WALL_TILE_COUNT (${WALL_TILE_COUNT})`, async () => {
+    const many = Array.from({ length: WALL_TILE_COUNT + 10 }, (_, i) =>
+      makeStoredTile({
+        status: 'approved',
+        createdAt: new Date(Date.parse('2026-07-01T00:00:00Z') + i * 1000).toISOString(),
+      }),
+    );
+    repository = new InMemoryTileRepository(many);
+    service = createTileService({ repository, imageStore: new InMemoryTileImageStore() });
+    const wall = await service.getWall();
+    expect(wall).toHaveLength(WALL_TILE_COUNT);
+    // Newest survive the bound.
+    expect(wall[0].createdAt).toBe(many[many.length - 1].createdAt);
+  });
+});
+
+let tileCounter = 0;
+
+function makeStoredTile(overrides: Partial<Tile>): Tile {
+  tileCounter += 1;
+  return {
+    id: `stored-${tileCounter}`,
+    imagePath: `stored-${tileCounter}.png`,
+    imageUrl: 'data:image/png;base64,',
+    status: 'pending',
+    submitterHash: HASH,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}

--- a/src/lib/doodle-wall/tileService.ts
+++ b/src/lib/doodle-wall/tileService.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { STORED_TILE_SIZE, SUBMIT_DAILY_CAP, TILE_MAX_BYTES, WALL_TILE_COUNT } from './constants';
 import { readPngDimensions } from './png';
 import type { TileImageStore, TileRepository } from './ports';
-import type { Tile } from './types';
+import type { Tile, WallTile } from './types';
 
 /**
  * The doodle wall's submit and wall rules, pure of HTTP and of Supabase.
@@ -16,8 +16,11 @@ export type SubmitTileResult =
 
 export interface TileService {
   submitTile(input: { imageBytes: Uint8Array; submitterHash: string }): Promise<SubmitTileResult>;
-  /** Most-recent approved tiles, newest first, bounded at WALL_TILE_COUNT. */
-  getWall(): Promise<Tile[]>;
+  /**
+   * Most-recent approved tiles, newest first, bounded at WALL_TILE_COUNT —
+   * already projected to the public WallTile shape.
+   */
+  getWall(): Promise<WallTile[]>;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -46,6 +49,10 @@ export function createTileService(deps: {
 
       // Durable daily cap, counted through the repository so it survives
       // serverless instance churn (unlike the route's in-memory burst guard).
+      // Count-then-insert is deliberately non-atomic: parallel submits at the
+      // boundary can land a few rows past the cap. Accepted — this is a spam
+      // bound feeding a pre-moderation queue, not a security boundary, and a
+      // transactional guard would need an RPC for no visitor-facing gain.
       const since = new Date(Date.now() - DAY_MS).toISOString();
       const submittedToday = await repository.countSubmittedSince(submitterHash, since);
       if (submittedToday >= SUBMIT_DAILY_CAP) return { ok: false, reason: 'daily-cap' };
@@ -61,12 +68,23 @@ export function createTileService(deps: {
         submitterHash,
         createdAt: new Date().toISOString(),
       };
-      await repository.insert(tile);
+      try {
+        await repository.insert(tile);
+      } catch (err) {
+        // Compensate: the upload preceded the failed insert, and nothing else
+        // references the image. Best-effort — the insert failure is the one
+        // worth surfacing.
+        await imageStore.remove(stored.path).catch(() => undefined);
+        throw err;
+      }
       return { ok: true, tile };
     },
 
     async getWall() {
-      return repository.recentApproved(WALL_TILE_COUNT);
+      // Public projection at the domain boundary: submitterHash and imagePath
+      // must never depend on each consumer remembering to strip them.
+      const tiles = await repository.recentApproved(WALL_TILE_COUNT);
+      return tiles.map(({ id, imageUrl, createdAt }) => ({ id, imageUrl, createdAt }));
     },
   };
 }

--- a/src/lib/doodle-wall/tileService.ts
+++ b/src/lib/doodle-wall/tileService.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from 'node:crypto';
+
+import { STORED_TILE_SIZE, SUBMIT_DAILY_CAP, TILE_MAX_BYTES, WALL_TILE_COUNT } from './constants';
+import { readPngDimensions } from './png';
+import type { TileImageStore, TileRepository } from './ports';
+import type { Tile } from './types';
+
+/**
+ * The doodle wall's submit and wall rules, pure of HTTP and of Supabase.
+ * Every rule the RLS policies also enforce is enforced here first — RLS is
+ * the backstop, not the only line (docs/adr/0001).
+ */
+
+export type SubmitTileResult =
+  { ok: true; tile: Tile } | { ok: false; reason: 'invalid-image' | 'too-large' | 'daily-cap' };
+
+export interface TileService {
+  submitTile(input: { imageBytes: Uint8Array; submitterHash: string }): Promise<SubmitTileResult>;
+  /** Most-recent approved tiles, newest first, bounded at WALL_TILE_COUNT. */
+  getWall(): Promise<Tile[]>;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function createTileService(deps: {
+  repository: TileRepository;
+  imageStore: TileImageStore;
+}): TileService {
+  const { repository, imageStore } = deps;
+
+  return {
+    async submitTile({ imageBytes, submitterHash }) {
+      // Byte ceiling before anything else — cheapest check on untrusted input.
+      if (imageBytes.byteLength > TILE_MAX_BYTES) return { ok: false, reason: 'too-large' };
+
+      // Server-side PNG validation: exact signature + IHDR dimensions. The
+      // client canvas exports 256×256, but the client is never trusted.
+      const dimensions = readPngDimensions(imageBytes);
+      if (
+        !dimensions ||
+        dimensions.width !== STORED_TILE_SIZE ||
+        dimensions.height !== STORED_TILE_SIZE
+      ) {
+        return { ok: false, reason: 'invalid-image' };
+      }
+
+      // Durable daily cap, counted through the repository so it survives
+      // serverless instance churn (unlike the route's in-memory burst guard).
+      const since = new Date(Date.now() - DAY_MS).toISOString();
+      const submittedToday = await repository.countSubmittedSince(submitterHash, since);
+      if (submittedToday >= SUBMIT_DAILY_CAP) return { ok: false, reason: 'daily-cap' };
+
+      const stored = await imageStore.store(imageBytes);
+      // Status is forced 'pending' — no caller can supply one; every tile
+      // enters the pre-moderation queue (CONTEXT.md).
+      const tile: Tile = {
+        id: randomUUID(),
+        imagePath: stored.path,
+        imageUrl: stored.url,
+        status: 'pending',
+        submitterHash,
+        createdAt: new Date().toISOString(),
+      };
+      await repository.insert(tile);
+      return { ok: true, tile };
+    },
+
+    async getWall() {
+      return repository.recentApproved(WALL_TILE_COUNT);
+    },
+  };
+}

--- a/src/lib/doodle-wall/types.ts
+++ b/src/lib/doodle-wall/types.ts
@@ -19,3 +19,14 @@ export interface Tile {
   /** ISO 8601 timestamp — string, so tiles serialise as-is. */
   createdAt: string;
 }
+
+/**
+ * The public projection of a Tile — the only tile shape that leaves the
+ * server (GET /api/wall). No imagePath, no submitterHash: the projection is
+ * applied at the domain boundary (tileService.getWall), not per consumer.
+ */
+export interface WallTile {
+  id: string;
+  imageUrl: string;
+  createdAt: string;
+}

--- a/src/lib/doodle-wall/types.ts
+++ b/src/lib/doodle-wall/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Doodle wall domain types (see CONTEXT.md). A tile is one visitor's single
+ * contribution; every submission enters the pre-moderation queue as `pending`
+ * and only reaches the wall once approved (ADR-0001).
+ */
+
+export type TileStatus = 'pending' | 'approved' | 'rejected';
+
+export interface Tile {
+  /** UUID, generated server-side — never client-supplied. */
+  id: string;
+  /** Storage path of the 256×256 PNG (bucket-relative). */
+  imagePath: string;
+  /** Publicly servable URL for the PNG (a data URI in stub mode). */
+  imageUrl: string;
+  status: TileStatus;
+  /** HMAC of the submitter's IP — abuse tracing without raw IPs at rest. */
+  submitterHash: string;
+  /** ISO 8601 timestamp — string, so tiles serialise as-is. */
+  createdAt: string;
+}

--- a/src/lib/supabase/serverClient.ts
+++ b/src/lib/supabase/serverClient.ts
@@ -1,0 +1,21 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Server-only Supabase client for the doodle wall adapters. Built with the
+ * service-role key, which bypasses RLS — it must never be imported from
+ * anything that can reach the client bundle. Only src/lib/supabase/ may
+ * import @supabase/supabase-js, and only API routes import this folder.
+ *
+ * Auth options follow the current server pattern: no session persistence,
+ * no token refresh, no URL detection — this client is a stateless
+ * per-instance singleton, not a user session.
+ */
+export function createServerClient(url: string, serviceRoleKey: string): SupabaseClient {
+  return createClient(url, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
+}

--- a/src/lib/supabase/tileAdapters.ts
+++ b/src/lib/supabase/tileAdapters.ts
@@ -40,6 +40,15 @@ export function getTileAdapters(): TileAdapters {
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!url || !anonKey || !serviceRoleKey) {
+    // A HALF-configured environment is a misconfiguration, not stub mode:
+    // silently serving fakes after provisioning (a rotated-out key, a renamed
+    // var) would 201 visitors' tiles into per-instance memory and lose them.
+    // Fully keyless stays legal — that is pre-provisioning stub mode.
+    if ((url || anonKey || serviceRoleKey) && process.env.VERCEL_ENV === 'production') {
+      throw new Error(
+        '[doodle-wall] partial Supabase env in production — set all of SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY or none',
+      );
+    }
     // Stub mode — module-level singletons so the seeded wall and submitted
     // tiles persist across requests within an instance.
     fakes ??= {

--- a/src/lib/supabase/tileAdapters.ts
+++ b/src/lib/supabase/tileAdapters.ts
@@ -1,0 +1,78 @@
+import {
+  InMemoryTileImageStore,
+  InMemoryTileRepository,
+  seedApprovedTiles,
+} from '@/lib/doodle-wall/fakes';
+import type { TileImageStore, TileRepository } from '@/lib/doodle-wall/ports';
+
+import { createServerClient } from './serverClient';
+import { SupabaseTileImageStore } from './tileImageStore';
+import { SupabaseTileRepository } from './tileRepository';
+
+/**
+ * The single place adapter selection happens (akin to FORTUNE_STUB): with
+ * any of SUPABASE_URL / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY
+ * absent, both API routes run against the in-memory fakes — dev, CI, and
+ * the currently-unprovisioned production are all keyless. The anon key is
+ * unused here (it is declared for Stage 2 admin auth) but still gates stub
+ * mode so a half-configured environment cannot half-work.
+ */
+
+export interface TileAdapters {
+  repository: TileRepository;
+  imageStore: TileImageStore;
+  submitterHashSecret: string;
+}
+
+/**
+ * Fixed hashing secret for stub mode only — fakes never leave the instance,
+ * so predictable hashes cost nothing. With real Supabase env present a
+ * missing SUBMITTER_HASH_SECRET fails loudly instead (see below).
+ */
+export const DEV_SUBMITTER_HASH_SECRET = 'doodle-wall-dev-only-secret';
+
+let fakes: { repository: TileRepository; imageStore: TileImageStore } | null = null;
+let supabase: { repository: TileRepository; imageStore: TileImageStore } | null = null;
+
+export function getTileAdapters(): TileAdapters {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !anonKey || !serviceRoleKey) {
+    // Stub mode — module-level singletons so the seeded wall and submitted
+    // tiles persist across requests within an instance.
+    fakes ??= {
+      repository: new InMemoryTileRepository(seedApprovedTiles()),
+      imageStore: new InMemoryTileImageStore(),
+    };
+    return {
+      ...fakes,
+      submitterHashSecret: process.env.SUBMITTER_HASH_SECRET || DEV_SUBMITTER_HASH_SECRET,
+    };
+  }
+
+  const submitterHashSecret = process.env.SUBMITTER_HASH_SECRET;
+  if (!submitterHashSecret) {
+    // Real backend + dev fallback would persist guessable submitter hashes
+    // (HMAC under a public constant) — refuse to run rather than degrade.
+    throw new Error(
+      '[doodle-wall] SUBMITTER_HASH_SECRET is required when the Supabase env is configured',
+    );
+  }
+
+  if (!supabase) {
+    const client = createServerClient(url, serviceRoleKey);
+    supabase = {
+      repository: new SupabaseTileRepository(client),
+      imageStore: new SupabaseTileImageStore(client),
+    };
+  }
+  return { ...supabase, submitterHashSecret };
+}
+
+/** Test hook: drop the singletons so each case starts from the seed. */
+export function resetTileAdapters(): void {
+  fakes = null;
+  supabase = null;
+}

--- a/src/lib/supabase/tileImageStore.ts
+++ b/src/lib/supabase/tileImageStore.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from 'node:crypto';
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { TileImageStore } from '@/lib/doodle-wall/ports';
+
+/** Storage bucket for tile PNGs: public read, server-only writes. */
+export const TILES_BUCKET = 'tiles';
+
+/**
+ * Supabase Storage implementation of the TileImageStore port. Dormant until
+ * Nick provisions the project — never constructed in stub mode.
+ */
+export class SupabaseTileImageStore implements TileImageStore {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async store(bytes: Uint8Array): Promise<{ path: string; url: string }> {
+    // Random server-side name — a user-influenced filename never reaches
+    // Storage, and the content type is pinned so tiles can only ever be
+    // served as image/png (tile bytes are untrusted user content).
+    const path = `${randomUUID()}.png`;
+    const { error } = await this.client.storage.from(TILES_BUCKET).upload(path, bytes, {
+      contentType: 'image/png',
+      upsert: false,
+    });
+    if (error) throw new Error(`[doodle-wall] tile image upload failed: ${error.message}`);
+    const { data } = this.client.storage.from(TILES_BUCKET).getPublicUrl(path);
+    return { path, url: data.publicUrl };
+  }
+}

--- a/src/lib/supabase/tileImageStore.ts
+++ b/src/lib/supabase/tileImageStore.ts
@@ -27,4 +27,9 @@ export class SupabaseTileImageStore implements TileImageStore {
     const { data } = this.client.storage.from(TILES_BUCKET).getPublicUrl(path);
     return { path, url: data.publicUrl };
   }
+
+  async remove(path: string): Promise<void> {
+    const { error } = await this.client.storage.from(TILES_BUCKET).remove([path]);
+    if (error) throw new Error(`[doodle-wall] tile image removal failed: ${error.message}`);
+  }
 }

--- a/src/lib/supabase/tileRepository.ts
+++ b/src/lib/supabase/tileRepository.ts
@@ -1,0 +1,73 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { TileRepository } from '@/lib/doodle-wall/ports';
+import type { Tile, TileStatus } from '@/lib/doodle-wall/types';
+
+import { TILES_BUCKET } from './tileImageStore';
+
+/**
+ * Supabase Postgres implementation of the TileRepository port, over the
+ * `tiles` table (supabase/migrations/*_doodle_wall.sql). Dormant until Nick
+ * provisions the project — never constructed in stub mode. Runs with the
+ * service-role client; the service layer enforces every rule the RLS
+ * policies also enforce.
+ */
+
+const TILE_COLUMNS = 'id, image_path, status, submitter_hash, created_at';
+
+interface TileRow {
+  id: string;
+  image_path: string;
+  status: TileStatus;
+  submitter_hash: string;
+  created_at: string;
+}
+
+export class SupabaseTileRepository implements TileRepository {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async insert(tile: Tile): Promise<void> {
+    const { error } = await this.client.from('tiles').insert({
+      id: tile.id,
+      image_path: tile.imagePath,
+      status: tile.status,
+      submitter_hash: tile.submitterHash,
+      created_at: tile.createdAt,
+    });
+    if (error) throw new Error(`[doodle-wall] tile insert failed: ${error.message}`);
+  }
+
+  async recentApproved(limit: number): Promise<Tile[]> {
+    const { data, error } = await this.client
+      .from('tiles')
+      .select(TILE_COLUMNS)
+      .eq('status', 'approved')
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (error) throw new Error(`[doodle-wall] wall query failed: ${error.message}`);
+    return ((data ?? []) as TileRow[]).map((row) => this.toTile(row));
+  }
+
+  async countSubmittedSince(submitterHash: string, sinceIso: string): Promise<number> {
+    const { count, error } = await this.client
+      .from('tiles')
+      .select('id', { count: 'exact', head: true })
+      .eq('submitter_hash', submitterHash)
+      .gte('created_at', sinceIso);
+    if (error) throw new Error(`[doodle-wall] daily-cap count failed: ${error.message}`);
+    return count ?? 0;
+  }
+
+  private toTile(row: TileRow): Tile {
+    // getPublicUrl is a synchronous URL construction — no network call.
+    const { data } = this.client.storage.from(TILES_BUCKET).getPublicUrl(row.image_path);
+    return {
+      id: row.id,
+      imagePath: row.image_path,
+      imageUrl: data.publicUrl,
+      status: row.status,
+      submitterHash: row.submitter_hash,
+      createdAt: row.created_at,
+    };
+  }
+}

--- a/src/store/scene.ts
+++ b/src/store/scene.ts
@@ -46,6 +46,17 @@ export type StrikerPhase = 'intro' | 'armed' | 'struck' | 'result' | 'done';
 /** Swings the visitor gets per high-striker round. */
 export const STRIKER_SWINGS = 3;
 
+/**
+ * Doodle-wall phase — drives the step-in overlay. Per-stroke drawing state
+ * lives in refs inside `<DoodleWallHud>`; only this summary reaches the store.
+ *   - `intro`      — just stepped in; the how-it-works card.
+ *   - `drawing`    — the wall + drawing surface are up; inks/brushes live.
+ *   - `submitting` — the tile is on its way to the pre-moderation queue.
+ *   - `submitted`  — accepted: "your tile is with the carny" confirmation.
+ *   - `error`      — the submit failed (rate-limited or otherwise); retry offered.
+ */
+export type DoodleWallPhase = 'intro' | 'drawing' | 'submitting' | 'submitted' | 'error';
+
 /** The high-striker slice reset to its pre-play state — the fresh round the
  *  visitor gets on step-in and on "reset". */
 const FRESH_STRIKER = {
@@ -173,6 +184,11 @@ export interface SceneState {
   /** Merge a partial summary update from the sim (score / balls / phase). */
   setBallToss: (patch: Partial<BallTossSlice>) => void;
 
+  /* --- Doodle-wall slice (summary only; strokes live in overlay refs) --- */
+  /** Current phase of the doodle-wall visit (drives the step-in overlay). */
+  doodleWallPhase: DoodleWallPhase;
+  setDoodleWallPhase: (phase: DoodleWallPhase) => void;
+
   /* --- High-striker game slice (summary only; the puck sim runs in refs) --- */
   strikerPhase: StrikerPhase;
   /** performance.now() when the meter armed — the needle is derived from this. */
@@ -260,13 +276,15 @@ export const useSceneStore = create<SceneState>()((set) => ({
   focus: (attraction) => set({ focusedAttraction: attraction }),
   open: (attraction) => set({ mode: 'viewing', activeAttraction: attraction }),
   close: () => set({ mode: 'travelling', activeAttraction: null, focusedAttraction: null }),
-  // Stepping into the high-striker gives a fresh round atomically (no HUD effect
+  // Stepping into a stall gives a fresh round/visit atomically (no HUD effect
   // reaching back to reset it once it sees `activeStall` change).
   stepIn: (stall) =>
     set(
       stall === 'high-striker'
         ? { mode: 'playing', activeStall: stall, ...FRESH_STRIKER }
-        : { mode: 'playing', activeStall: stall },
+        : stall === 'doodle-wall'
+          ? { mode: 'playing', activeStall: stall, doodleWallPhase: 'intro' }
+          : { mode: 'playing', activeStall: stall },
     ),
   // Also clear focusedAttraction so IsoControls releases the booth and the iso
   // camera eases back to the overview (otherwise it stays parked at the stall).
@@ -278,6 +296,9 @@ export const useSceneStore = create<SceneState>()((set) => ({
   ballTossRound: 0,
   resetBallToss: () =>
     set({ ballTossScore: 0, ballTossBallsLeft: BALL_TOSS_BALLS, ballTossPhase: 'intro' }),
+
+  doodleWallPhase: 'intro',
+  setDoodleWallPhase: (doodleWallPhase) => set({ doodleWallPhase }),
 
   strikerPhase: 'intro',
   strikerArmedAt: 0,

--- a/supabase/migrations/20260714115029_doodle_wall.sql
+++ b/supabase/migrations/20260714115029_doodle_wall.sql
@@ -1,0 +1,64 @@
+-- Doodle wall (ADR-0001): the tiles table, its pre-moderation queue, and
+-- public wall reads. Reviewed-only until Nick provisions the Supabase
+-- project — this file runs at that gate, never in CI.
+--
+-- RLS here is the backstop: the API routes run with the service-role key
+-- (bypassing RLS) and tileService enforces every rule below first. The
+-- policies exist so a leaked anon key still cannot read the queue or
+-- promote a tile.
+
+-- One row per visitor contribution (a tile, CONTEXT.md).
+create table public.tiles (
+  id uuid primary key default gen_random_uuid(),
+  image_path text not null,
+  status text not null default 'pending'
+    constraint tiles_status_check check (status in ('pending', 'approved', 'rejected')),
+  submitter_hash text not null,
+  created_at timestamptz not null default now(),
+  -- Null until Stage 2 moderation approves the tile.
+  approved_at timestamptz
+);
+
+-- The wall query: most-recent approved, newest first. Partial index — the
+-- approved subset stays small and pending/rejected rows never bloat it.
+create index tiles_wall_idx on public.tiles (created_at desc)
+  where status = 'approved';
+
+-- The daily-cap count: equality column (submitter_hash) first, range column
+-- (created_at) last, per the leftmost-prefix rule.
+create index tiles_submitter_window_idx on public.tiles (submitter_hash, created_at);
+
+alter table public.tiles enable row level security;
+
+-- Anon may insert only into the pre-moderation queue — a submission can
+-- never arrive pre-approved.
+create policy "anon submits tiles as pending only"
+  on public.tiles
+  for insert
+  to anon
+  with check (status = 'pending');
+
+-- Anon may read only approved tiles; the queue is invisible publicly.
+create policy "anon reads approved tiles only"
+  on public.tiles
+  for select
+  to anon
+  using (status = 'approved');
+
+-- No anon update/delete policies: status changes are admin-only (Stage 2).
+
+-- Storage bucket for tile PNGs: public read, no public write. The bucket
+-- itself pins the content type and the 128 KB tile cap (defence in depth —
+-- tileService enforces both before any upload).
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values ('tiles', 'tiles', true, 131072, array['image/png'])
+on conflict (id) do nothing;
+
+-- Public read of tile images. No insert/update/delete policies exist for
+-- this bucket, so writes only happen through the server adapter
+-- (service role), which pins contentType image/png.
+create policy "public read of tile images"
+  on storage.objects
+  for select
+  to anon, authenticated
+  using (bucket_id = 'tiles');

--- a/supabase/migrations/20260714115029_doodle_wall.sql
+++ b/supabase/migrations/20260714115029_doodle_wall.sql
@@ -4,8 +4,11 @@
 --
 -- RLS here is the backstop: the API routes run with the service-role key
 -- (bypassing RLS) and tileService enforces every rule below first. The
--- policies exist so a leaked anon key still cannot read the queue or
--- promote a tile.
+-- policies exist so a leaked (or, from Stage 2, browser-shipped) anon key
+-- cannot read the queue, promote a tile — or write at all. There is NO anon
+-- insert policy: every legitimate write goes through the service role, so an
+-- anon insert grant would only hand queue-flooding to anon-key holders,
+-- bypassing tileService's PNG/size/daily-cap checks.
 
 -- One row per visitor contribution (a tile, CONTEXT.md).
 create table public.tiles (
@@ -30,14 +33,6 @@ create index tiles_submitter_window_idx on public.tiles (submitter_hash, created
 
 alter table public.tiles enable row level security;
 
--- Anon may insert only into the pre-moderation queue — a submission can
--- never arrive pre-approved.
-create policy "anon submits tiles as pending only"
-  on public.tiles
-  for insert
-  to anon
-  with check (status = 'pending');
-
 -- Anon may read only approved tiles; the queue is invisible publicly.
 create policy "anon reads approved tiles only"
   on public.tiles
@@ -45,7 +40,8 @@ create policy "anon reads approved tiles only"
   to anon
   using (status = 'approved');
 
--- No anon update/delete policies: status changes are admin-only (Stage 2).
+-- No anon insert/update/delete policies: submissions go through the server
+-- (service role) only; status changes are admin-only (Stage 2).
 
 -- Storage bucket for tile PNGs: public read, no public write. The bucket
 -- itself pins the content type and the 128 KB tile cap (defence in depth —


### PR DESCRIPTION
## What this is

The **doodle wall** (ADR-0001) — the communal stall at the end of the Midway. Stage 1 ships the full visitor path: view the wall of approved tiles in the scene, step in, draw a tile (Full **and** Lite), and submit it into the **pre-moderation queue**. Stage 2 (admin moderation view + keepalive cron) follows separately.

Runs entirely in **stub mode** until Supabase is provisioned — in-memory fakes serve a seeded wall and accept submissions, so this is fully reviewable and deployable keyless.

## Shape (loose hexagonal)

- `src/lib/doodle-wall/` — domain: types (incl. the public `WallTile` projection), server-truth constants, ports, `tileService` (PNG validation, forced-`pending` status, durable daily cap, insert-failure compensation), in-memory fakes
- `src/lib/supabase/` — adapters (dormant; the only folder importing supabase-js) + a production tripwire for a partial env
- `POST /api/tiles` / `GET /api/wall` — thin route adapters mirroring the fortune route's conventions
- `supabase/migrations/…_doodle_wall.sql` — tiles table, wall + daily-cap indexes, RLS (anon reads approved only; **no anon writes**), Storage bucket
- Scene: `DoodleWall.tsx` (bulb-strung tile board at the Midway's end, own `?off=doodle` gate) + `doodleWallConfig.ts`
- Overlay: `DoodleWallHud.tsx` (512→256 drawing surface, neon-on-dark palette, undo/clear, the carny copy); the `#doodle-wall` hash from `StaticCv` routes through `stepIn()` so mode-keyed chrome behaves

## Process receipts

- Grill session closed all open parameters (recorded in `docs/redesign/doodle-wall-handoff.md` §5)
- glossary-guard: clean after fixes (the carny added to CONTEXT.md)
- /code-review (high): 12 confirmed findings fixed in `c43bf60`; 8 verified cleanups parked as follow-ons in the handoff
- docs-scribe: STATUS / architecture / ADR-0001 synced
- Gate: `typecheck · lint · test:ci (120) · build` green, keyless

## Before merge (Nick)

- [ ] Real-GPU look pass: stall placement, board, bulb string, overlay palette (builder screenshots predate the review fixes)
- [ ] Copy sign-off: the carny confirmation + error cards
- [ ] (Post-merge, before going live) Provision Supabase: create project → run the migration → set all four env vars together

🤖 Generated with [Claude Code](https://claude.com/claude-code)