### PR TITLE
feat(doodle-wall): Stage 2 — the carny's counter (/admin), verdicts, keepalive

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -30,11 +30,12 @@ FORTUNE_STUB=
 # @sensitive @optional
 REDIS_URL=
 
-# Doodle wall backend (ADR-0001, /api/tiles + /api/wall). With ANY of the
-# three Supabase vars absent, both routes run in stub mode against in-memory
-# fakes (seeded wall, per-instance submissions) — dev, CI, and the
-# currently-unprovisioned production all run keyless. The anon key is unused
-# by this slice; it is declared now for Stage 2 admin (moderation) auth.
+# Doodle wall backend (ADR-0001, /api/tiles + /api/wall + /admin). With ANY
+# of the three Supabase vars absent, the routes run in stub mode against
+# in-memory fakes (seeded wall, per-instance submissions) and /admin is
+# inert — dev, CI, and a keyless deployment all run without them. The anon
+# key drives the Stage 2 admin cookie-session auth (server-side only — it
+# never reaches the client bundle).
 # The project URL is NOT a secret (same reasoning as the Sentry DSN): every
 # Storage public URL that GET /api/wall returns embeds it, so marking it
 # sensitive makes varlock's runtime leak scan (correctly) find it in the
@@ -53,6 +54,13 @@ SUPABASE_SERVICE_ROLE_KEY=
 # hashes minted under a public constant.
 # @sensitive @optional
 SUBMITTER_HASH_SECRET=
+
+# Guard for /api/keepalive (the daily Supabase-keepalive cron, vercel.json).
+# When set, Vercel's cron sends it as `Authorization: Bearer <value>` and the
+# route rejects other callers; absent, the route is open (it only reads one
+# already-public tile). Server-only, never in a response — stays @sensitive.
+# @sensitive @optional
+CRON_SECRET=
 
 # Sentry (refactor Phase 7) — absent = no telemetry (init is gated on the DSN).
 # A Sentry DSN is NOT a secret: it's write-only (submits events, can't read them)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,5 +77,13 @@ The holding area every submitted tile enters. Nick reviews and approves/rejects 
 _Avoid_: review board, moderation inbox
 
 **The carny**:
-The unseen stallholder persona the doodle wall's copy hands a submitted tile to ("your tile is with the carny") — the in-world face of the pre-moderation queue. Purely narrative; the actual moderator is Nick.
+The stallholder persona of the doodle wall's pre-moderation queue. Visitors meet him in copy ("your tile is with the carny"); Nick _is_ the carny at the carny's counter — the allow-listed /admin account acts in his name. Internal identifiers (`MODERATOR_EMAILS`, `kind: 'moderator'`) stay technical.
 _Avoid_: moderator (in visitor-facing copy), attendant, admin (as a character)
+
+**The carny's counter**:
+/admin — the page where the carny reviews the pre-moderation queue and gives verdicts. A plain DOM page (no canvas): not an attraction, not a stall, not an overlay. "Counter" is deliberate — "booth" stays banned (see Stall).
+_Avoid_: booth, admin panel/dashboard (in copy), back office
+
+**Verdict**:
+The carny's single ruling on a queued tile: approve (publishes to the wall) or reject (final — a rejected tile is never restored; an approved tile can later be rejected to take it down). Code carries it as `Verdict`; the moderation route's body field is `verdict`.
+_Avoid_: decision, action (in copy), ban/delete

--- a/docs/redesign/doodle-wall-handoff.md
+++ b/docs/redesign/doodle-wall-handoff.md
@@ -9,9 +9,9 @@
 > (`.claude/agents/carnival-context.md`). Builders are briefed from it; outcomes are folded
 > back in. Read `CONTEXT.md` first — its language is law.
 >
-> Stage 1 merged from `feature/doodle-wall`; live fix branch:
-> `fix/mobile-framing-and-npc-paths` (carries the e2e fix `6cc67f9` + the
-> mobile framing fix). PRs target `master`.
+> Stage 1 merged and live (PRs #65–#68). Stage 2 built on
+> `feature/doodle-wall-moderation` (working tree; PR to follow). PRs target
+> `master`.
 
 ---
 
@@ -19,95 +19,104 @@
 
 Two stages, each its own PR:
 
-1. **Stage 1 — visitor path:** ✅ **complete and LIVE-VERIFIED end to end**
-   (2026-07-14). PR #65 merged (`12d4a39`), storage-listing PR #66 merged (`cbcd832`),
-   Supabase provisioned and migrated, all four env vars set (`.env.local` + Vercel),
-   and the real-Supabase end-to-end check passed locally (§6). One fix outstanding:
-   the e2e surfaced a varlock leak-scan bug that would have 500'd `GET /api/wall` on
-   the first approved tile in production — fixed (`6cc67f9`), now riding
-   `fix/mobile-framing-and-npc-paths` together with the mobile framing fix,
-   **PR to follow** (§1, §5, §7).
-2. **Stage 2 — moderation:** `/admin` queue (Supabase Auth, Google OAuth, **hard
-   allow-list of Nick's account only**), approve/reject route, daily keepalive cron.
-   **Do not start** until the e2e-fix PR is merged, Nick has done his real-GPU look
-   pass on the board, and Nick supplies his Google identity.
+1. **Stage 1 — visitor path:** ✅ **complete, LIVE-VERIFIED end to end, and fully
+   merged.** PR #65 (`12d4a39`), storage-listing PR #66 (`cbcd832`), e2e varlock
+   fix PR #67 (`0e60a41`) and mobile-framing PR #68 (`4631df6`) all on master;
+   Supabase provisioned, all four env vars set, real-Supabase e2e passed (§6).
+2. **Stage 2 — moderation:** ✅ **BUILT** (2026-07-15) on
+   `feature/doodle-wall-moderation` (working tree, **PR to follow**): `/admin` —
+   the carny's counter — over the pre-moderation queue (Supabase Auth, Google
+   OAuth, hard allow-list `nick@iamnick.dev` only), verdict route, daily
+   keepalive cron. Gate green, 149 tests, close-out chain done. `/admin` stays
+   in its "unconfigured" state until Nick does the Google OAuth config —
+   **§5 Needs Nick is the gate.**
 
-## 1. Current state (verified 2026-07-15, master `cbcd832`)
+## 1. Current state (verified 2026-07-15, `feature/doodle-wall-moderation` over master `4631df6`)
 
-**Stage 1 is merged, provisioned, and live-verified end to end.** Gate green at
-`c43bf60` (typecheck / lint / test:ci, 120 tests keyless / build); CI green on both
-PRs through merge; the real-Supabase end-to-end check passed locally (§6).
+**Stage 1 is merged, provisioned, and live-verified end to end. Stage 2
+(moderation) is BUILT** — staged/working-tree on this branch, gate green
+(typecheck / lint / test:ci with 149 tests keyless / build), close-out chain
+done, **PR to follow**. `/admin` renders its "unconfigured" state until Nick
+does the Google OAuth config (§5 Needs Nick).
 
-- **Backend** (`58bf8ad`, `6d758dc`): domain layer `src/lib/doodle-wall/` (`types.ts` —
-  now also home of the public `WallTile` shape — `constants.ts`, `ports.ts`, `png.ts`,
-  `submitterHash.ts`, `tileService.ts`, `fakes.ts`, colocated tests); thin routes
+**Stage 1 (all merged to master):**
+
+- **Backend:** domain layer `src/lib/doodle-wall/` (`types.ts` — home of the public
+  `WallTile` shape — `constants.ts`, `ports.ts`, `png.ts`, `submitterHash.ts`,
+  `tileService.ts`, `fakes.ts`, colocated tests); thin routes
   `src/app/api/tiles/route.ts` (+ sibling `rateLimit.ts`, burst 2/min/IP) and
-  `src/app/api/wall/route.ts`; Supabase adapters in `src/lib/supabase/` (dormant until
-  the env vars are set; supabase-js confined there, grep-verified; `TileImageStore` now has
-  `remove()` for insert-failure compensation). Migration
-  `supabase/migrations/20260714115029_doodle_wall.sql`: tiles table + indexes, RLS
-  **select-approved-only — the anon INSERT policy was dropped** (every legitimate write
-  goes through the service role), `tiles` bucket public-read with 128KB + image/png
-  bucket-level limits. `.env.schema`: 4 vars, all `@sensitive @optional`; absent env =
-  stub mode, **partial Supabase env in production throws** (tripwire in the adapter
-  factory).
-- **Scene** (`f06f27a`, `20ecc3c`, `bc376a7`, revised `4860738`):
-  `three/game/doodleWallConfig.ts` (three-free; re-exports server truths and
-  `WallTile`; own tests) and `three/game/DoodleWall.tsx` — a **freestanding**
-  bulb-strung 6×4 tile-grid board on poles in the NE fence corner at three
-  **(17.5, 39)**, fed by `GET /api/wall`. **No stall prefab** — the Stall_03 first
-  placed at (12.5, 36.8) sat inside the big tree canopy there and read as "inside a
-  tent" (Nick). Attraction entry `doodle-wall` (section `game:doodle-wall`) in
-  `synty/attractions.ts`; `Attraction.prefab` is now optional (unconsumed metadata) and
-  absent for this entry. Own bisection key `?off=doodle` (`?off=game` again means only
-  the game sims).
-- **Overlay + store** (`c600659`, `c902fa5`): `overlays/DoodleWallHud.tsx` — step-in
-  overlay showing the approved wall (`<img>` grid) plus the 512→256 drawing surface
-  (palette / 3 brushes / undo 20 / clear) and submit. Store slice in `src/store/scene.ts`:
-  `doodleWallPhase` (`intro | drawing | submitting | submitted | error`) +
-  `setDoodleWallPhase`; `stepIn('doodle-wall')` resets the phase atomically.
-  `#doodle-wall` hash-open routes through `stepIn()` so mode-keyed chrome (burger,
-  ticket tally) yields correctly; `StaticCv` links to a server-rendered
-  `id="doodle-wall"` target for the no-canvas tier.
-- **Merged:** PR #65 → master `12d4a39` (2026-07-14). Close-out chain (`5a2df8d`
-  glossary-guard, `c43bf60` review fixes), docs sync (`b4bc279`) and the board-only
-  revision (`4860738`) are all in.
-- **Supabase provisioned (this session, via the CLI):** project **iamnick**, ref
-  `hzwjezozoxlopyfgmxoc`, Central EU (Frankfurt), created 2026-07-14. `supabase link` +
-  `supabase db push` applied `20260714115029_doodle_wall.sql`; `supabase migration
-list` shows local/remote in sync. Verified on the remote: `public.tiles` exists with
-  RLS enabled and exactly one policy ("anon reads approved tiles only", SELECT to
-  anon); `tiles` bucket public, 131072 file-size limit, image/png only.
-- **Storage-listing fix (security follow-up): ✅ merged as PR #66 (`cbcd832`).**
-  `supabase/migrations/20260714203433_drop_tiles_listing_policy.sql` drops the
-  "public read of tile images" SELECT policy on `storage.objects` (advisor
-  `0025_public_bucket_allows_listing`: on a public bucket its only effect was letting
-  anon LIST — enumerating pending/rejected tile PNGs). Applied remotely, advisors
-  clean, and **verified live by the e2e**: an anon bucket-listing attempt returned
-  `[]` while the object itself served fine by public URL.
-- **Real mode is live:** Nick set all four env vars in `.env.local` AND Vercel —
-  using the **legacy JWT-format keys** (§5 provisioning canon). Both routes leave
-  stub mode wherever the env is present; the end-to-end check confirmed real mode
-  locally (§6).
-- **Live fix branch (`fix/mobile-framing-and-npc-paths`, PR to follow):** carries
-  the e2e fix as commit `6cc67f9` — `SUPABASE_URL` flipped to `@sensitive=false` in
-  `.env.schema`; without it varlock's runtime leak scan 500s `GET /api/wall` the
-  moment any approved tile exists (§7). Same commit gitignores `supabase/.temp/`
-  and `.mcp.json` (Nick's ask).
-- **Mobile framing fix (same branch, 2026-07-15, uncommitted at absorb time):**
-  Nick reported the board cropped on phones during the fly-in. `Attraction`
-  (`synty/attractions.ts`) gained an optional `frameWidth` — a world width (m)
-  that must stay in frame when focused; `IsoControls` backs the camera off beyond
-  `focusDist` on narrow viewports until that width fits the horizontal fov (fov 34
-  is fixed, so portrait aspect shrinks the h-fov). The `doodle-wall` entry declares
-  `frameWidth: 3.6` (BOARD_W 2.93 + pole/bulb margin). Verified by headless
-  portrait (390×844) screenshot: full 6×4 grid, bulbs and both poles in frame
-  during the fly-in; desktop framing unchanged (5.5 m still governs where the
-  width already fits). No other attraction declares one. The branch also carries
-  non-doodle-wall mobile fixes (intro camera aspect compensation, burger gated on
-  `started`, NPC walker re-routes + `scripts/walker-clearance.mjs`).
-- Supabase MCP server configured in `.mcp.json` (now gitignored), pointed at the
-  project ref; not yet OAuth-connected in-session — the CLI is the working path.
+  `src/app/api/wall/route.ts`; Supabase adapters in `src/lib/supabase/`
+  (supabase-js confined there, grep-verified). Migrations applied remotely: tiles
+  table + RLS **select-approved-only, no anon INSERT** (all writes service-role);
+  `tiles` bucket public-read, 128KB + image/png limits, listing policy dropped
+  (PR #66). Absent env = stub mode; **partial Supabase env in production throws**.
+- **Scene:** `three/game/doodleWallConfig.ts` (three-free; re-exports server truths
+  and `WallTile`) and `three/game/DoodleWall.tsx` — a **freestanding** bulb-strung
+  6×4 tile-grid board on poles in the NE fence corner at three **(17.5, 39)**, fed
+  by `GET /api/wall`; no stall prefab (Nick's revision `4860738`). Attraction entry
+  `doodle-wall` in `synty/attractions.ts` declares `frameWidth: 3.6` (mobile
+  framing, PR #68). Own bisection key `?off=doodle`.
+- **Overlay + store:** `overlays/DoodleWallHud.tsx` — step-in overlay showing the
+  approved wall (`<img>` grid) plus the 512→256 drawing surface
+  (palette / 3 brushes / undo 20 / clear) and submit. Store slice `doodleWallPhase`
+  (`intro | drawing | submitting | submitted | error`) in `src/store/scene.ts`;
+  `stepIn('doodle-wall')` resets it atomically; `#doodle-wall` hash-open routes
+  through `stepIn()`; `StaticCv` carries a server-rendered target for the
+  no-canvas tier.
+- **Merged PRs:** #65 Stage 1 (`12d4a39`), #66 storage-listing drop (`cbcd832`),
+  #67 e2e varlock fix (`0e60a41`, carries `6cc67f9` — `SUPABASE_URL`
+  `@sensitive=false`, §7), #68 mobile framing + NPC re-routes (`4631df6` —
+  optional `Attraction.frameWidth` honoured by `IsoControls`; portrait-verified).
+- **Supabase live:** project **iamnick**, ref `hzwjezozoxlopyfgmxoc`, Central EU
+  (Frankfurt); migrations local/remote in sync, advisors clean; all four env vars
+  set (`.env.local` + Vercel, legacy JWT-format keys — §5); real-Supabase
+  end-to-end check PASSED 2026-07-14 (§6).
+
+**Stage 2 (this branch, built 2026-07-15, staged/working tree):**
+
+- **Domain:** `tileService` gained `getQueue()` — oldest-first `pending`, bounded by
+  the new constant `QUEUE_PAGE_COUNT` (48), projected through a shared `toWallTile`
+  helper, **the** privacy boundary (`submitterHash`/`imagePath` never cross it) —
+  and `moderate({ id, verdict })` with the transition rules: approve
+  `pending→approved`; reject `pending|approved→rejected` (approved→rejected = a
+  takedown); **rejected is final**. `TileRepository` port gained
+  `oldestPending` / `findById` / `setStatus`. The Supabase adapter maintains
+  `approved_at` (set on approve, cleared otherwise) and maps Postgres `22P02`
+  invalid-uuid to `null`, so malformed ids 404 rather than 500.
+- **Auth (`src/lib/supabase/adminAuth.ts`, server-only):** `@supabase/ssr` 0.12.3
+  cookie sessions, all server-side — **the anon key never reaches the client
+  bundle**. `getClaims()` (JWKS-verified) + hard allow-list
+  `MODERATOR_EMAILS = ['nick@iamnick.dev']`, moved OUT of `doodle-wall/constants.ts`
+  into this server-only module (structural boundary — `constants.ts` is
+  client-reachable via `doodleWallConfig`), + a **provider pin**: the session must
+  be Google (`app_metadata.provider(s)`), so an email/password account claiming the
+  carny's address can never pass. The configured-predicate matches
+  `getTileAdapters` (all three Supabase vars, or stub). `requestOrigin()` pins to
+  `SITE_URL` in production (`x-forwarded-host` never steers redirects);
+  dev/preview use the request URL origin. No middleware/proxy — one page, one
+  person; an expired token simply reads as signed-out.
+- **Routes:** `GET /api/admin/auth/login` (server-side `signInWithOAuth` google →
+  303), `GET …/callback` (`exchangeCodeForSession` → `/admin`; failures →
+  `/admin?auth=error`), `POST …/logout`. `PATCH /api/admin/tiles/:id` — contract in
+  §2.1. `GET /api/keepalive` → `{ ok, mode: 'live' | 'stub' }` with an optional
+  `CRON_SECRET` guard (timing-safe compare); `vercel.json` cron daily 08:00 UTC.
+  `.env.schema`: new `CRON_SECRET` (`@sensitive @optional`); the
+  `SUPABASE_ANON_KEY` comment updated (drives admin auth, server-only).
+- **UI:** `/admin` is **the carny's counter** (CONTEXT.md gained entries _The
+  carny's counter_ and _Verdict_; _The carny_ widened — Nick IS the carny at the
+  counter; "moderation queue" copy corrected to the canon "pre-moderation queue").
+  Server page with four identity states
+  (unconfigured / anonymous / denied / moderator), letterpress ticket-frame
+  styling, noindex + `robots.ts` disallow `/admin` and `/api/`. `AdminQueue`
+  client component: oldest-first cards, approve/reject per tile, stale cards
+  dropped only on tile-level reasons (not bare 404s), keyed remount on refresh so
+  `router.refresh()` actually updates the list.
+- **Tests:** 149 total (was 120 pre-Stage-2): tileService queue + verdict rules,
+  adminAuth allow-list, PATCH route (guards + verdicts), keepalive, `AdminQueue`
+  component. Gate green; stub-mode `/admin` smoke-tested by portrait screenshot.
+- **Close-out chain done:** glossary-guard (5 findings → counter/verdict renames +
+  the CONTEXT.md entries) and /code-review high (24 candidates → 10 confirmed,
+  all fixed; list in §5).
 
 ## 2. Architecture (binding)
 
@@ -132,12 +141,14 @@ src/lib/supabase/             adapter: server/service-role clients + port implem
 schema/query design) for any Supabase work; `security-best-practices` for any API surface;
 the relevant `r3f-*` skill for canvas work; `building-components` for overlay work.
 
-### 2.1 Landed contracts (Stage 2 builds against these — do not renegotiate)
+### 2.1 Landed contracts (do not renegotiate)
 
 **Server truths** (`src/lib/doodle-wall/constants.ts` — re-exported by
 `doodleWallConfig.ts`, never redefined): `STORED_TILE_SIZE` 256, `DRAWING_CANVAS_SIZE`
 512, `TILE_MAX_BYTES` 131072, `WALL_TILE_COUNT` 48, `SCENE_TILE_COUNT` 24,
-`SUBMIT_BURST_PER_MINUTE` 2, `SUBMIT_DAILY_CAP` 10.
+`QUEUE_PAGE_COUNT` 48, `SUBMIT_BURST_PER_MINUTE` 2, `SUBMIT_DAILY_CAP` 10.
+`MODERATOR_EMAILS` is deliberately NOT here — it lives in the server-only
+`src/lib/supabase/adminAuth.ts` (§5).
 
 **`POST /api/tiles`** — body `{ "image": "<base64 PNG, no data: prefix>" }`, raw request
 ceiling 204800 bytes, byte-accurate (`Buffer.byteLength`) with a Content-Length
@@ -151,6 +162,22 @@ as `{ error }` JSON: 400 `invalid-request` | `invalid-image`, 413 `too-large`, 4
 boundary). Newest first, ≤48, `Cache-Control: public, s-maxage=60,
 stale-while-revalidate=300`. In stub mode `imageUrl` is a `data:image/png;base64,` URI;
 with Supabase it is a Storage public URL — **consumers must handle both**.
+
+**Pre-moderation queue (domain, no public route)** — the queue is server-rendered
+into `/admin`, never exposed anonymously. `tileService.getQueue()`: oldest-first
+`pending`, ≤ `QUEUE_PAGE_COUNT` (48), projected to `WallTile` through the same
+`toWallTile` helper as `getWall()` — the single privacy boundary.
+
+**`PATCH /api/admin/tiles/:id`** — body `{ "verdict": "approve" | "reject" }`.
+200 → `{ id, status }`. Errors as `{ error }` JSON: 401 anonymous, 403 for both
+not-the-carny AND bad-origin (the same cross-site Origin rejection as
+`POST /api/tiles`), 400 bad body, 404 unknown/malformed id, 409
+invalid-transition, 503 stub mode. Transitions: approve `pending→approved`;
+reject `pending|approved→rejected`; rejected is final.
+
+**`GET /api/keepalive`** — 200 → `{ ok, mode: 'live' | 'stub' }`. If `CRON_SECRET`
+is set, the bearer token must match (timing-safe compare); unset means open.
+Driven by the `vercel.json` cron, daily 08:00 UTC.
 
 ## 3. Feature spec (v1)
 
@@ -172,23 +199,25 @@ with Supabase it is a Storage public URL — **consumers must handle both**.
 
 ## 4. File map
 
-| Piece                              | Path                                                                          | Stage | Status                                           |
-| ---------------------------------- | ----------------------------------------------------------------------------- | ----- | ------------------------------------------------ |
-| SQL migration (tiles, RLS, bucket) | `supabase/migrations/20260714115029_doodle_wall.sql`                          | 1     | ✅ done + applied remotely                       |
-| Storage-listing fix migration      | `supabase/migrations/20260714203433_drop_tiles_listing_policy.sql`            | 1     | ✅ merged (PR #66, `cbcd832`)                    |
-| Domain: types, ports, service      | `src/lib/doodle-wall/`                                                        | 1     | ✅ done                                          |
-| Supabase clients + adapters        | `src/lib/supabase/` (dormant until provisioning)                              | 1     | ✅ done                                          |
-| Submit route (thin) + rate limiter | `src/app/api/tiles/route.ts` + `rateLimit.ts`                                 | 1     | ✅ done                                          |
-| Wall route (thin, cacheable)       | `src/app/api/wall/route.ts`                                                   | 1     | ✅ done                                          |
-| Env vars (4, all optional)         | `.env.schema` (SUPABASE_URL/ANON_KEY/SERVICE_ROLE_KEY, SUBMITTER_HASH_SECRET) | 1     | ✅ set live; URL-sensitivity fix PR pending (§5) |
-| Tuning config (three-free) + tests | `src/components/three/game/doodleWallConfig.ts`                               | 1     | ✅ done                                          |
-| In-scene stall + tile grid         | `src/components/three/game/DoodleWall.tsx`                                    | 1     | ✅ done                                          |
-| Drawing overlay                    | `src/components/overlays/DoodleWallHud.tsx`                                   | 1     | ✅ done                                          |
-| Store slice                        | `src/store/scene.ts` (`doodleWallPhase`)                                      | 1     | ✅ done                                          |
-| Attraction entry                   | `src/components/three/synty/attractions.ts` (`doodle-wall`)                   | 1     | ✅ done                                          |
-| Admin queue page                   | `src/app/admin/page.tsx`                                                      | 2     | —                                                |
-| Approve/reject route               | `src/app/api/admin/tiles/[id]/route.ts`                                       | 2     | —                                                |
-| Keepalive route + cron             | `src/app/api/keepalive/route.ts` + Vercel cron                                | 2     | —                                                |
+| Piece                               | Path                                                                                       | Stage | Status                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------------ | ----- | --------------------------------------------------- |
+| SQL migration (tiles, RLS, bucket)  | `supabase/migrations/20260714115029_doodle_wall.sql`                                       | 1     | ✅ done + applied remotely                          |
+| Storage-listing fix migration       | `supabase/migrations/20260714203433_drop_tiles_listing_policy.sql`                         | 1     | ✅ merged (PR #66, `cbcd832`)                       |
+| Domain: types, ports, service       | `src/lib/doodle-wall/`                                                                     | 1     | ✅ done                                             |
+| Supabase clients + adapters         | `src/lib/supabase/` (dormant until provisioning)                                           | 1     | ✅ done                                             |
+| Submit route (thin) + rate limiter  | `src/app/api/tiles/route.ts` + `rateLimit.ts`                                              | 1     | ✅ done                                             |
+| Wall route (thin, cacheable)        | `src/app/api/wall/route.ts`                                                                | 1     | ✅ done                                             |
+| Env vars (5, all optional)          | `.env.schema` (SUPABASE_URL/ANON_KEY/SERVICE_ROLE_KEY, SUBMITTER_HASH_SECRET, CRON_SECRET) | 1+2   | ✅ 4 set live; CRON_SECRET optional (§5 Needs Nick) |
+| Tuning config (three-free) + tests  | `src/components/three/game/doodleWallConfig.ts`                                            | 1     | ✅ done                                             |
+| In-scene stall + tile grid          | `src/components/three/game/DoodleWall.tsx`                                                 | 1     | ✅ done                                             |
+| Drawing overlay                     | `src/components/overlays/DoodleWallHud.tsx`                                                | 1     | ✅ done                                             |
+| Store slice                         | `src/store/scene.ts` (`doodleWallPhase`)                                                   | 1     | ✅ done                                             |
+| Attraction entry                    | `src/components/three/synty/attractions.ts` (`doodle-wall`)                                | 1     | ✅ done                                             |
+| The carny's counter (page + queue)  | `src/app/admin/page.tsx` + `AdminQueue.tsx`                                                | 2     | ✅ built (working tree)                             |
+| Verdict route                       | `src/app/api/admin/tiles/[id]/route.ts`                                                    | 2     | ✅ built (working tree)                             |
+| Auth routes (login/callback/logout) | `src/app/api/admin/auth/*/route.ts`                                                        | 2     | ✅ built (working tree)                             |
+| Admin auth (server-only)            | `src/lib/supabase/adminAuth.ts` (allow-list, provider pin, origin pin)                     | 2     | ✅ built (working tree)                             |
+| Keepalive route + cron              | `src/app/api/keepalive/route.ts` + `vercel.json`                                           | 2     | ✅ built (working tree)                             |
 
 ## 5. Decisions
 
@@ -238,7 +267,50 @@ programmatically.
 - Daily-cap count-then-insert TOCTOU is **accepted and documented** (worst case: a
   racer lands one tile over cap; pre-moderation queue absorbs it).
 
+**Stage 2 decisions (build session, 2026-07-15 — now canon):**
+
+- **Allow-list is structural, not just data:** `MODERATOR_EMAILS` lives in the
+  server-only `src/lib/supabase/adminAuth.ts`, never in
+  `doodle-wall/constants.ts` (client-reachable via `doodleWallConfig`). Hard-coded
+  `['nick@iamnick.dev']` — never widen (ADR-0001).
+- **Provider pin:** a passing session must be a Google session
+  (`app_metadata.provider(s)`); an email/password signup claiming the carny's
+  address can never pass, even before the dashboard-side provider is disabled.
+- **Origin pin:** `requestOrigin()` returns `SITE_URL` in production —
+  `x-forwarded-host` never steers OAuth redirects. Dev/preview use the request
+  URL origin.
+- **No middleware/proxy** for `/admin` — one page, one person; an expired token
+  reads as signed-out and the page re-offers login.
+- **Verdict transitions** (encoded in `tileService.moderate`): approve
+  `pending→approved`; reject `pending|approved→rejected` (approved→rejected is a
+  takedown); rejected is FINAL — never restored.
+- The Supabase adapter owns `approved_at` (set on approve, cleared otherwise);
+  `findById` maps Postgres `22P02` to `null` so malformed ids 404.
+- **Glossary additions (CONTEXT.md):** _The carny's counter_ (= `/admin`; plain
+  DOM page, not an attraction/stall/overlay; "booth" stays banned) and _Verdict_
+  (approve | reject); _The carny_ widened — Nick IS the carny at the counter.
+
+**Stage 2 close-out fixes (code review, 2026-07-15 — 24 candidates, 10 confirmed,
+all fixed):** queue-refresh no-op (keyed remount so `router.refresh()` bites);
+provider pin; forwarded-host trust in redirects; timing-safe `CRON_SECRET`
+compare; blind 404 card-drop (stale cards now dropped only on tile-level
+reasons); configured-predicate disagreement with `getTileAdapters`; `22P02` →
+500 (now 404); missing Origin check on PATCH; duplicated privacy projection
+(now one `toWallTile`); allow-list in a client-reachable module (moved to
+`adminAuth.ts`).
+
 **Parked follow-ons (verified in review, deliberately not fixed — pick up post-merge):**
+
+- **(Stage 2)** Atomic transition port method — a single conditional UPDATE instead
+  of `findById` + `setStatus` (the `setStatus` write is unconfirmed against the
+  read; the race window is Nick-vs-Nick, so parked).
+- **(Stage 2)** Rate limiting on the admin auth routes.
+- **(Stage 2)** Pin session cookie flags explicitly rather than inheriting
+  `@supabase/ssr` defaults.
+- **(Stage 2)** `requireModerator()` route-preamble helper — extract when a second
+  admin route appears.
+- **(Stage 2)** Card-shell dedup across `/admin` + the `AdminQueue` empty state —
+  joins the existing `CardShell` follow-on below.
 
 - Card chrome triplicated across `overlays/BallTossHud.tsx` / `HighStrikerHud.tsx` /
   `DoodleWallHud.tsx` → extract a shared `overlays/CardShell`.
@@ -271,37 +343,51 @@ programmatically.
   verified working by the e2e. A later swap to the new-format keys (`sb_secret_...` /
   `sb_publishable_...`) needs **no code change**; the adapters are format-agnostic.
   The anon key is unused until Stage 2.
-- `SUPABASE_URL` is `@sensitive=false` in `.env.schema` (e2e fix, branch
-  `fix/doodle-wall-e2e-provisioning`): every Storage public URL that `GET /api/wall`
-  returns embeds the project URL, so marking it sensitive made varlock's runtime leak
-  scan 500 the route as soon as any tile was approved. Same reasoning as the Sentry
-  DSN precedent already in `.env.schema`; Stage 2 ships the URL to the browser anyway.
+- `SUPABASE_URL` is `@sensitive=false` in `.env.schema` (e2e fix `6cc67f9`, merged
+  PR #67): every Storage public URL that `GET /api/wall` returns embeds the project
+  URL, so marking it sensitive made varlock's runtime leak scan 500 the route as
+  soon as any tile was approved. Same reasoning as the Sentry DSN precedent. The
+  anon key, by contrast, **stays `@sensitive`** — Stage 2 kept it server-only
+  (cookie sessions, no client-side Supabase).
 - The rejected e2e test tile stays in the project (canon: rows and PNGs retained) —
   row `315595ae-efe4-477f-929f-8f0f3362e61e`, image
   `973052c3-1ed7-45b1-98e4-30cb8dbd219a.png`, status `rejected`. Not a stray; do not
   clean it up.
 
-**Open:**
-
-- Admin queue UX details (batch approve, preview size) — resolve at Stage 2 start.
+**Open:** none — the Stage 2 queue UX questions (batch approve, preview size)
+were resolved by the build: one verdict per tile, no batching; card previews.
 
 **Needs Nick (human gates):**
 
-- **Merge the fix PR** (from `fix/mobile-framing-and-npc-paths`, carrying the e2e
-  fix `6cc67f9` + the mobile framing fix; PR to follow) — without it production
-  500s `GET /api/wall` on the first approved tile and crops the board on phones.
+- **Stage 2 config gate — `/admin` cannot work until this is done:**
+  1. Google Cloud Console (console.cloud.google.com/auth/clients): create an
+     OAuth client (web application), Authorized redirect URI =
+     `https://hzwjezozoxlopyfgmxoc.supabase.co/auth/v1/callback`.
+  2. Supabase dashboard → Auth → Providers → Google: enable, paste the client ID
+     - secret.
+  3. Supabase dashboard → Auth → URL Configuration: Site URL
+     `https://iamnick.dev`; add to the redirect allow-list
+     `https://iamnick.dev/api/admin/auth/callback` and
+     `http://localhost:3000/api/admin/auth/callback`.
+  4. RECOMMENDED: disable the email/password provider (defence in depth — the
+     provider pin already blocks it).
+  5. Optionally set `CRON_SECRET` in the Vercel env.
+  6. Then the Stage 2 e2e per §6: sign in on the phone → a pending tile appears
+     at the counter → approve → on the wall; a non-allow-listed account → denied.
 - **Real-GPU look pass** on the freestanding board (outstanding since `4860738`,
-  now including the mobile fly-in framing on a real phone) — headless swiftshader
-  can't judge colour/glow; also eyeball the error cards and the `#doodle-wall`
-  hash entry, still unexercised visually (§6).
-- Stage 2 admin allow-list uses Nick's actual Google identity — collect it at Stage 2
-  start; never widen to "any Google login" (ADR-0001).
+  including the mobile fly-in framing on a real phone) — headless swiftshader
+  can't judge colour/glow; also eyeball the error cards, the `#doodle-wall` hash
+  entry, and now the carny's counter styling (§6).
 
 ## 6. How to verify
 
 - **Gate (every slice):** `pnpm typecheck && pnpm lint && pnpm test:ci && pnpm build`
-  — all green at `c43bf60` (120 tests, keyless).
-- **Domain + routes + config:** ✅ covered by colocated unit tests against fakes.
+  — all green at the Stage 2 head (149 tests, keyless).
+- **Domain + routes + config:** ✅ covered by colocated unit tests against fakes —
+  Stage 2 added tileService queue + verdict rules, adminAuth allow-list, PATCH
+  route guards + verdicts, keepalive, and the `AdminQueue` component.
+- **The carny's counter, stub mode:** ✅ smoke-tested by portrait screenshot
+  (unconfigured state renders; no auth possible pre-config).
 - **Scene/overlay headless:** recipe in `ball-toss-game-handoff.md` §6 (Playwright +
   swiftshader, `?debug=1` + `window.__sceneStore`; `?off=doodle` isolates the wall).
   ✅ Re-verified at `4860738`: fly-in frames the freestanding board (grid + bulbs +
@@ -320,8 +406,13 @@ programmatically.
   PNG fetched anonymously by its Storage public URL (200, byte-identical) → anon
   bucket-listing returned `[]` (listing-policy drop live) → SQL approve → wall served
   it with the real Storage URL → SQL reject → wall empty again. Test tile retained by
-  design (ids in §5). Still to come at Stage 2: non-allow-listed Google account
-  denied `/admin`.
+  design (ids in §5).
+- **Stage 2 end-to-end (after Nick's config gate, §5):** sign in at `/admin` on
+  the phone with the allow-listed account → a submitted tile appears at the
+  counter as `pending` → approve → it reaches `GET /api/wall`; reject an approved
+  tile → it leaves the wall (takedown); a non-allow-listed Google account →
+  denied; `GET /api/keepalive` → `{ ok: true, mode: 'live' }` (with the bearer
+  token if `CRON_SECRET` is set).
 - **Degradation:** WebGL off → `StaticCv` link → overlay with `<img>` tiles.
 
 ## 7. Gotchas (inherited — details in `ball-toss-game-handoff.md` §7)
@@ -343,8 +434,8 @@ programmatically.
   or varlock's runtime leak scan (patched `Response.json`) 500s the route the moment
   the value shows up. Found live by the e2e: `SUPABASE_URL` sits inside every approved
   tile's `imageUrl`, so a sensitive URL killed `GET /api/wall` on the first approved
-  tile. Check this for every future var — the Stage 2 anon/publishable key ships to
-  the client and needs the same treatment when it does.
+  tile. Check this for every future var. (The anon key dodged it — Stage 2 kept it
+  server-only, so it stays `@sensitive`.)
 - Bisection keys: `?off=doodle` unmounts the wall; `?off=game` covers only the game sims.
 - Nick's dev server usually holds port 3000 — smoke servers go on a spare port.
 - Commit messages end `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
@@ -366,49 +457,46 @@ programmatically.
     Nick, `.env.local` + Vercel, legacy JWT keys (§5); ~~stub→real end-to-end
     check~~ ✅ **PASSED** (§6) — and found + fixed the varlock `SUPABASE_URL` bug
     en route (§7).
-11. **← YOU ARE HERE. Blocked on Nick:** (a) merge the fix PR (from
-    `fix/mobile-framing-and-npc-paths` — e2e fix + mobile framing) → (b) real-GPU
-    look pass on the board, desktop and mobile (outstanding since `4860738`).
-12. Stage 2: admin + keepalive, same shape (brief from this doc; contracts in §2.1;
-    needs Nick's Google identity for the allow-list before any code).
+11. ~~Merge the fix PRs~~ ✅ #67 (`0e60a41`, e2e varlock fix) and #68 (`4631df6`,
+    mobile framing + NPC re-routes) merged to master.
+12. ~~Stage 2: admin + keepalive~~ ✅ **built 2026-07-15** on
+    `feature/doodle-wall-moderation` (staged/working tree; gate green, 149 tests;
+    glossary-guard + /code-review close-out done — §1, §5).
+13. **← YOU ARE HERE:** (a) raise the Stage 2 PR → (b) **Nick's config gate**
+    (§5 Needs Nick: Google OAuth client, Supabase provider + URL config, optional
+    `CRON_SECRET`) → (c) the Stage 2 end-to-end check (§6). In parallel, Nick's
+    real-GPU look pass on the board is still outstanding (since `4860738`).
 
 ## 9. What just happened
 
-2026-07-15 (latest) — **mobile framing fixed** on `fix/mobile-framing-and-npc-paths`
-(cut from the e2e fix, which it carries as `6cc67f9`; one PR to follow with both).
-Nick reported the board cropped on phones during the fly-in ("needs zooming out
-when camera pans in"). Fix: optional `frameWidth` on `Attraction`
-(`synty/attractions.ts`) — a world width that must stay in frame when focused —
-honoured by `IsoControls`, which backs the camera off beyond `focusDist` on narrow
-viewports until the width fits the horizontal fov; `doodle-wall` declares 3.6 m.
-Headless portrait (390×844) screenshot verified the full 6×4 grid, bulbs and both
-poles in frame; desktop framing unchanged; no other attraction declares a
-`frameWidth`. The branch also carries mobile fixes outside doodle-wall scope
-(intro camera, burger gating, NPC walker re-routes). Nick's real-GPU look pass
-(§5) now covers the mobile look too.
+2026-07-15 (latest) — **Stage 2 (moderation) BUILT** on
+`feature/doodle-wall-moderation` (staged/working tree; PR to follow). One slice,
+same hexagonal shape: `tileService.getQueue()` + `moderate()` with the verdict
+transition rules (rejected is final), new `TileRepository` port methods, the
+server-only `adminAuth.ts` (cookie sessions via `@supabase/ssr`, JWKS-verified
+claims, hard allow-list `nick@iamnick.dev`, Google provider pin, production
+origin pin), the three auth routes, `PATCH /api/admin/tiles/:id`,
+`GET /api/keepalive` + the `vercel.json` daily cron, and `/admin` — the carny's
+counter (four identity states, `AdminQueue` client component, noindex + robots
+disallow). CONTEXT.md gained _The carny's counter_ and _Verdict_. Gate green
+with 149 tests (was 120); stub-mode `/admin` smoke-tested by portrait
+screenshot. Close-out done: glossary-guard (5 findings) and /code-review high
+(10 confirmed fixed — §5); five new Stage 2 follow-ons parked (§5). **Nothing
+works at `/admin` in production until Nick's config gate (§5 Needs Nick):**
+Google OAuth client + Supabase provider/URL config, then the Stage 2 e2e (§6).
+Earlier the same day the fix PRs merged: #67 (`0e60a41`, the e2e varlock
+`SUPABASE_URL` fix) and #68 (`4631df6`, mobile framing via
+`Attraction.frameWidth` + NPC re-routes) — master is `4631df6`.
 
-2026-07-14 — **Stage 1 live-verified end to end against the real Supabase
-project.** PR #66 (storage-listing policy drop) merged to master (`cbcd832`); Nick set
-all four env vars in `.env.local` and Vercel — with the legacy JWT-format keys (canon
-note §5). The full real-mode chain then passed locally (prod build, port 3001):
-submit → `pending` and invisible → remote row + `submitter_hash` verified → PNG
-served anonymously by public URL, byte-identical → anon listing returns `[]` (the
-#66 drop verified live) → SQL approve → on the wall with a real Storage URL → SQL
-reject → wall empty again; the rejected test tile is retained by design (ids in §5).
-The e2e also **found a bug production would have hit on the first approved tile**:
-`SUPABASE_URL` marked `@sensitive` made varlock's runtime leak scan 500
-`GET /api/wall` because every `imageUrl` embeds the project URL. Fixed
-(`@sensitive=false`, Sentry-DSN precedent) as `6cc67f9`, alongside gitignoring
-`supabase/.temp/` and `.mcp.json` (Nick's ask). **Remaining before Stage 2**
-(§8 step 11): merge the fix PR, Nick's real-GPU look pass (outstanding since
-`4860738`), and Nick's Google identity for the admin allow-list.
-
-Earlier the same day: PR #65 merged (`12d4a39`); Supabase provisioned via the CLI
-(project **iamnick**, ref `hzwjezozoxlopyfgmxoc`, Central EU Frankfurt; migrations
-applied and remote state verified, advisors clean after the listing-policy drop);
-and before merge, the close-out chain (`5a2df8d`, `c43bf60`, `b4bc279`) and Nick's
-board-only revision (`4860738` — stall prefab dropped, freestanding board at three
-(17.5, 39)).
+2026-07-14 — **Stage 1 shipped end to end.** PR #65 merged (`12d4a39`) after the
+close-out chain (`5a2df8d`, `c43bf60`, `b4bc279`) and Nick's board-only revision
+(`4860738`). Supabase provisioned via the CLI (project **iamnick**, ref
+`hzwjezozoxlopyfgmxoc`, Frankfurt); storage-listing PR #66 merged (`cbcd832`);
+Nick set all four env vars (legacy JWT keys, §5); the real-Supabase e2e passed
+locally — the full submit → pending → approve → wall → reject chain, anon
+listing blocked, test tile retained by design (§5, §6). The e2e found the
+varlock `SUPABASE_URL` leak-scan bug that would have 500'd `GET /api/wall` on
+the first approved tile (§7); fixed as `6cc67f9`.
 
 For a NEW session picking this up: read `CONTEXT.md`, then this doc top to bottom —
 §2.1 has the frozen contracts, §5 the canon decisions + parked follow-ons, §8 the next

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@react-three/fiber": "^9.6.1",
     "@react-three/postprocessing": "^3.0.4",
     "@sentry/nextjs": "^10.65.0",
+    "@supabase/ssr": "^0.12.3",
     "@supabase/supabase-js": "^2.110.2",
     "@varlock/nextjs-integration": "1.1.4",
     "@vercel/analytics": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.65.0
         version: 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(react@19.2.7)(webpack@5.108.4)
+      '@supabase/ssr':
+        specifier: ^0.12.3
+        version: 0.12.3(@supabase/supabase-js@2.110.2)
       '@supabase/supabase-js':
         specifier: ^2.110.2
         version: 2.110.2
@@ -1496,6 +1499,11 @@ packages:
     resolution: {integrity: sha512-z3jTOTPgyn6E3r6dVOOQ10He4yAMB2czjFw7xVdX3s16MHElna5rY1gVaePs0NIo6xvtMYbtmOXlFaFt/ePLpg==}
     engines: {node: '>=22.0.0'}
 
+  '@supabase/ssr@0.12.3':
+    resolution: {integrity: sha512-qWXJ/dI7CiYDKyTgIPqJ4Qkh8y5edh2LdF/nkN48z47mmEVzAO2OE+YErYeQ/UemVfonn/F4kFz+lhLqoVMdpw==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.110.5
+
   '@supabase/storage-js@2.110.2':
     resolution: {integrity: sha512-EhsRSwSnmQefKJsAxoRUZ0hvHr92ECM8DDGAKR5z0HdoJx4heI60PjHUTruVNZxKX6XeobLGDyLud020Bw1iwg==}
     engines: {node: '>=22.0.0'}
@@ -2144,6 +2152,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -5209,6 +5221,11 @@ snapshots:
       '@supabase/phoenix': 0.4.4
       tslib: 2.8.1
 
+  '@supabase/ssr@0.12.3(@supabase/supabase-js@2.110.2)':
+    dependencies:
+      '@supabase/supabase-js': 2.110.2
+      cookie: 1.1.1
+
   '@supabase/storage-js@2.110.2':
     dependencies:
       iceberg-js: 0.8.1
@@ -5885,6 +5902,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   cross-env@7.0.3:
     dependencies:

--- a/src/app/admin/AdminQueue.test.tsx
+++ b/src/app/admin/AdminQueue.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WallTile } from '@/lib/doodle-wall/types';
+
+import { AdminQueue } from './AdminQueue';
+
+const refresh = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+const TILES: WallTile[] = [
+  { id: 'tile-a', imageUrl: 'data:image/png;base64,', createdAt: '2026-07-15T10:00:00.000Z' },
+  { id: 'tile-b', imageUrl: 'data:image/png;base64,', createdAt: '2026-07-15T11:00:00.000Z' },
+];
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockResolvedValue(new Response(JSON.stringify({ id: 'tile-a', status: 'approved' })));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('AdminQueue', () => {
+  it('shows one card per pending tile with both verdicts', () => {
+    render(<AdminQueue initialTiles={TILES} />);
+    expect(screen.getByText(/2 awaiting review/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Approve' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Reject' })).toHaveLength(2);
+  });
+
+  it('PATCHes a verdict and strikes the card', async () => {
+    const user = userEvent.setup();
+    render(<AdminQueue initialTiles={TILES} />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Approve' })[0]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/tiles/tile-a',
+      expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ verdict: 'approve' }) }),
+    );
+    expect(screen.getByText(/1 awaiting review/i)).toBeInTheDocument();
+  });
+
+  it('drops a stale card on 409 without an error banner', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'invalid-transition' }), { status: 409 }),
+    );
+    const user = userEvent.setup();
+    render(<AdminQueue initialTiles={TILES} />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Reject' })[0]);
+
+    expect(screen.getByText(/1 awaiting review/i)).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('keeps the card on a bare platform 404 (no tile-level reason) — deploy skew must not eat verdicts', async () => {
+    fetchMock.mockResolvedValue(new Response('Not Found', { status: 404 }));
+    const user = userEvent.setup();
+    render(<AdminQueue initialTiles={TILES} />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Approve' })[0]);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/2 awaiting review/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a transient failure and keeps the card', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    const user = userEvent.setup();
+    render(<AdminQueue initialTiles={TILES} />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Approve' })[0]);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/2 awaiting review/i)).toBeInTheDocument();
+  });
+
+  it('offers Check again when the queue is clear', async () => {
+    const user = userEvent.setup();
+    render(<AdminQueue initialTiles={[]} />);
+    await user.click(screen.getByRole('button', { name: 'Check again' }));
+    expect(refresh).toHaveBeenCalled();
+  });
+});

--- a/src/app/admin/AdminQueue.tsx
+++ b/src/app/admin/AdminQueue.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import type { Verdict } from '@/lib/doodle-wall/tileService';
+import type { WallTile } from '@/lib/doodle-wall/types';
+
+/**
+ * The queue itself — one card per pending tile, oldest first (first drawn,
+ * first reviewed), each with the only two verdicts that exist. Client
+ * component so a verdict can strike the card without a reload; the server
+ * page hands in the initial queue and router.refresh() re-pulls it.
+ *
+ * imageUrl is a data URI in stub mode and a Storage URL live — <img> takes
+ * both (same contract as the overlay's wall grid).
+ */
+
+/** Deterministic UTC stamp — server and client render identically. */
+const stamp = (iso: string) => `${iso.slice(0, 10)} ${iso.slice(11, 16)} UTC`;
+
+export function AdminQueue({ initialTiles }: { initialTiles: WallTile[] }) {
+  const router = useRouter();
+  const [tiles, setTiles] = useState(initialTiles);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const decide = async (id: string, verdict: Verdict) => {
+    setBusy(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/tiles/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ verdict }),
+      });
+      const payload = (await res.json().catch(() => ({}))) as { error?: string };
+      // Drop the card on success — or when the queue is stale (verdict
+      // already given: not-found / invalid-transition from OUR route, by
+      // reason rather than bare status, so a platform 404 mid-deploy can't
+      // silently swallow verdicts).
+      if (res.ok || payload.error === 'not-found' || payload.error === 'invalid-transition') {
+        setTiles((current) => current.filter((tile) => tile.id !== id));
+      } else {
+        setError(payload.error ?? 'something went wrong — try again');
+      }
+    } catch {
+      setError('something went wrong — try again');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (tiles.length === 0) {
+    return (
+      <section className="ticket-frame halftone mt-8 rounded-[5px] p-6 text-center">
+        <p className="font-fell text-[15px] italic leading-relaxed text-ink/90">
+          The queue is clear — nothing awaiting the carny.
+        </p>
+        <button
+          type="button"
+          onClick={() => router.refresh()}
+          className="paper-button mt-6 rounded-[3px] px-5 py-2 font-fell-sc text-[14px] tracking-[0.06em]"
+        >
+          Check again
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mt-8" aria-label="Pending tiles">
+      <div className="flex items-center justify-between">
+        <p className="font-fell-sc text-[13px] tracking-[0.1em] text-ink-soft">
+          {tiles.length} awaiting review, oldest first
+        </p>
+        <button
+          type="button"
+          onClick={() => router.refresh()}
+          className="font-fell-sc text-[12px] tracking-[0.06em] text-brass-text underline-offset-2 hover:underline"
+        >
+          refresh
+        </button>
+      </div>
+
+      {error && (
+        <p role="alert" className="font-fell-sc mt-3 text-[13px] tracking-[0.06em] text-accent">
+          {error}
+        </p>
+      )}
+
+      <ul className="mt-4 grid gap-4 sm:grid-cols-2">
+        {tiles.map((tile) => (
+          <li key={tile.id} className="ticket-frame halftone rounded-[5px] p-4">
+            {/* Untrusted visitor art: a plain image, never markup. */}
+            <img
+              src={tile.imageUrl}
+              alt="Pending doodle tile"
+              width={256}
+              height={256}
+              className="mx-auto aspect-square w-full max-w-[256px] rounded-[3px] bg-[#0d0d12]"
+            />
+            <p className="font-fell mt-3 text-center text-[12px] italic text-ink-soft/80">
+              drawn {stamp(tile.createdAt)}
+            </p>
+            <div className="mt-3 flex gap-3">
+              {(['approve', 'reject'] as const).map((verdict) => (
+                <button
+                  key={verdict}
+                  type="button"
+                  disabled={busy === tile.id}
+                  onClick={() => decide(tile.id, verdict)}
+                  className={`paper-button flex-1 rounded-[3px] px-4 py-3 font-fell-sc text-[14px] tracking-[0.06em] disabled:opacity-40${
+                    verdict === 'reject' ? ' text-accent' : ''
+                  }`}
+                >
+                  {verdict === 'approve' ? 'Approve' : 'Reject'}
+                </button>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,116 @@
+import type { Metadata } from 'next';
+
+import { createTileService } from '@/lib/doodle-wall/tileService';
+import { getAdminIdentity } from '@/lib/supabase/adminAuth';
+import { getTileAdapters } from '@/lib/supabase/tileAdapters';
+
+import { AdminQueue } from './AdminQueue';
+
+/**
+ * /admin — the carny's counter: the doodle wall's pre-moderation queue
+ * (ADR-0001, Stage 2). Server component, no caching: identity comes from the
+ * session cookie (getClaims-verified in the adapter) and every render shows
+ * the live queue. Phone-first — approving tiles from Nick's phone is the
+ * designed workflow.
+ *
+ * Four states: pre-provisioning stub (inert), signed out (Google sign-in),
+ * signed in but not the carny (denied + sign-out), and the carny (queue).
+ */
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'The carny’s counter',
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ auth?: string }>;
+}) {
+  const identity = await getAdminIdentity();
+  const { auth } = await searchParams;
+
+  return (
+    <main className="min-h-screen bg-background-primary px-4 py-16">
+      <div className="mx-auto w-full max-w-2xl">
+        <header className="text-center">
+          <p className="font-fell-sc text-[13px] tracking-[0.22em] text-brass-text">
+            the carny&rsquo;s counter
+          </p>
+          <h1 className="font-rye letterpress mt-2 text-[34px] text-ink">Pre-moderation Queue</h1>
+        </header>
+
+        {identity.kind === 'unconfigured' && (
+          <section className="ticket-frame halftone mt-8 rounded-[5px] p-6 text-center">
+            <p className="font-fell text-[15px] leading-relaxed text-ink/90">
+              The counter is dark — no Supabase environment is configured, so the site is running in
+              stub mode and there is no real queue to review.
+            </p>
+          </section>
+        )}
+
+        {identity.kind === 'anonymous' && (
+          <section className="ticket-frame halftone mt-8 rounded-[5px] p-6 text-center">
+            {auth === 'error' && (
+              <p className="font-fell-sc mb-4 text-[13px] tracking-[0.06em] text-accent">
+                Sign-in didn&rsquo;t complete — try again.
+              </p>
+            )}
+            <p className="font-fell text-[15px] leading-relaxed text-ink/90">
+              Carny only past this point.
+            </p>
+            <a
+              href="/api/admin/auth/login"
+              className="paper-button mt-6 inline-block rounded-[3px] px-6 py-3 font-fell-sc text-[15px] tracking-[0.06em]"
+            >
+              Sign in with Google
+            </a>
+          </section>
+        )}
+
+        {identity.kind === 'denied' && (
+          <section className="ticket-frame halftone mt-8 rounded-[5px] p-6 text-center">
+            <p className="font-fell text-[15px] leading-relaxed text-ink/90">
+              <span className="font-fell-sc">{identity.email}</span> isn&rsquo;t the carny — this
+              counter serves exactly one person.
+            </p>
+            <form action="/api/admin/auth/logout" method="post">
+              <button
+                type="submit"
+                className="paper-button mt-6 rounded-[3px] px-6 py-3 font-fell-sc text-[15px] tracking-[0.06em]"
+              >
+                Sign out
+              </button>
+            </form>
+          </section>
+        )}
+
+        {identity.kind === 'moderator' && <ModeratorView email={identity.email} />}
+      </div>
+    </main>
+  );
+}
+
+async function ModeratorView({ email }: { email: string }) {
+  const queue = await createTileService(getTileAdapters()).getQueue();
+  return (
+    <>
+      <div className="mt-4 flex items-center justify-center gap-3">
+        <p className="font-fell text-[13px] italic text-ink-soft/80">{email}</p>
+        <form action="/api/admin/auth/logout" method="post">
+          <button
+            type="submit"
+            className="font-fell-sc text-[12px] tracking-[0.06em] text-brass-text underline-offset-2 hover:underline"
+          >
+            sign out
+          </button>
+        </form>
+      </div>
+      {/* Keyed by content: router.refresh() re-runs this server component,
+          and a changed queue must REMOUNT the client list — its useState
+          snapshot never re-reads the prop on its own. */}
+      <AdminQueue key={queue.map((tile) => tile.id).join('|')} initialTiles={queue} />
+    </>
+  );
+}

--- a/src/app/api/admin/auth/callback/route.ts
+++ b/src/app/api/admin/auth/callback/route.ts
@@ -1,0 +1,21 @@
+import { createAdminAuthClient, requestOrigin } from '@/lib/supabase/adminAuth';
+
+/**
+ * GET /api/admin/auth/callback — the OAuth return leg: exchange the code
+ * for a cookie session, then land on /admin (which applies the allow-list;
+ * ANY Google account can complete this exchange, but only the carny's gets
+ * past the counter). This URL must be in Supabase's redirect allow-list.
+ */
+export const runtime = 'nodejs';
+
+export async function GET(req: Request): Promise<Response> {
+  const origin = requestOrigin(req);
+  const client = await createAdminAuthClient();
+  const code = new URL(req.url).searchParams.get('code');
+
+  if (client && code) {
+    const { error } = await client.auth.exchangeCodeForSession(code);
+    if (!error) return Response.redirect(`${origin}/admin`, 303);
+  }
+  return Response.redirect(`${origin}/admin?auth=error`, 303);
+}

--- a/src/app/api/admin/auth/login/route.ts
+++ b/src/app/api/admin/auth/login/route.ts
@@ -1,0 +1,24 @@
+import { createAdminAuthClient, requestOrigin } from '@/lib/supabase/adminAuth';
+
+/**
+ * GET /api/admin/auth/login — start the carny's Google sign-in (ADR-0001).
+ * Server-side OAuth: signInWithOAuth writes the PKCE verifier cookie and
+ * hands back Google's authorisation URL; we redirect there. The callback
+ * route completes the exchange. No Supabase client in the browser.
+ */
+export const runtime = 'nodejs';
+
+export async function GET(req: Request): Promise<Response> {
+  const client = await createAdminAuthClient();
+  // Stub mode: /admin explains the provisioning gate; nothing to sign into.
+  if (!client) return Response.redirect(`${requestOrigin(req)}/admin`, 303);
+
+  const { data, error } = await client.auth.signInWithOAuth({
+    provider: 'google',
+    options: { redirectTo: `${requestOrigin(req)}/api/admin/auth/callback` },
+  });
+  if (error || !data.url) {
+    return Response.redirect(`${requestOrigin(req)}/admin?auth=error`, 303);
+  }
+  return Response.redirect(data.url, 303);
+}

--- a/src/app/api/admin/auth/logout/route.ts
+++ b/src/app/api/admin/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { createAdminAuthClient, requestOrigin } from '@/lib/supabase/adminAuth';
+
+/**
+ * POST /api/admin/auth/logout — clear the carny's session (also the exit for
+ * a denied account to sign in with the right one). POST, not GET: a
+ * navigation must not be able to sign the carny out cross-site.
+ */
+export const runtime = 'nodejs';
+
+export async function POST(req: Request): Promise<Response> {
+  const client = await createAdminAuthClient();
+  await client?.auth.signOut();
+  return Response.redirect(`${requestOrigin(req)}/admin`, 303);
+}

--- a/src/app/api/admin/tiles/[id]/route.test.ts
+++ b/src/app/api/admin/tiles/[id]/route.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { seedApprovedTiles } from '@/lib/doodle-wall/fakes';
+import type { AdminIdentity } from '@/lib/supabase/adminAuth';
+import { getTileAdapters, resetTileAdapters } from '@/lib/supabase/tileAdapters';
+
+import { PATCH } from './route';
+
+/**
+ * Route-handler tests, keyless (stub mode) and offline. The auth adapter is
+ * mocked per-case — its own allow-list rule is unit-tested in
+ * src/lib/supabase/adminAuth.test.ts; here it is an input.
+ */
+
+const identity = vi.hoisted(() => ({ current: { kind: 'moderator', email: 'nick@iamnick.dev' } }));
+
+vi.mock('@/lib/supabase/adminAuth', () => ({
+  getAdminIdentity: () => Promise.resolve(identity.current),
+}));
+
+const setIdentity = (value: AdminIdentity) => {
+  identity.current = value as typeof identity.current;
+};
+
+const patchTile = async (id: string, body: unknown) => {
+  const res = await PATCH(
+    new Request(`http://localhost/api/admin/tiles/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  );
+  return { res, body: (await res.json()) as Record<string, string> };
+};
+
+const seedPending = async (id: string) => {
+  await getTileAdapters().repository.insert({
+    ...seedApprovedTiles()[0],
+    id,
+    status: 'pending',
+  });
+};
+
+beforeEach(() => {
+  vi.stubEnv('SUPABASE_URL', '');
+  vi.stubEnv('SUPABASE_ANON_KEY', '');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '');
+  resetTileAdapters();
+  setIdentity({ kind: 'moderator', email: 'nick@iamnick.dev' });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('PATCH /api/admin/tiles/:id — the carny gate', () => {
+  it('401s a signed-out caller before touching anything', async () => {
+    setIdentity({ kind: 'anonymous' });
+    const { res, body } = await patchTile('whatever', { verdict: 'approve' });
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ error: 'unauthorized' });
+  });
+
+  it('403s a signed-in account that is not the carny', async () => {
+    setIdentity({ kind: 'denied', email: 'mallory@example.com' });
+    const { res, body } = await patchTile('whatever', { verdict: 'approve' });
+    expect(res.status).toBe(403);
+    expect(body).toEqual({ error: 'forbidden' });
+  });
+
+  it('503s in pre-provisioning stub mode', async () => {
+    setIdentity({ kind: 'unconfigured' });
+    const { res } = await patchTile('whatever', { verdict: 'approve' });
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('PATCH /api/admin/tiles/:id — verdicts', () => {
+  it('approves a pending tile', async () => {
+    await seedPending('queued-1');
+    const { res, body } = await patchTile('queued-1', { verdict: 'approve' });
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ id: 'queued-1', status: 'approved' });
+  });
+
+  it('rejects a pending tile', async () => {
+    await seedPending('queued-2');
+    const { res, body } = await patchTile('queued-2', { verdict: 'reject' });
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ id: 'queued-2', status: 'rejected' });
+  });
+
+  it('400s a body without a legal verdict', async () => {
+    await seedPending('queued-3');
+    for (const bad of [{ verdict: 'promote' }, {}, 'not-json{{']) {
+      const { res, body } = await patchTile('queued-3', bad);
+      expect(res.status).toBe(400);
+      expect(body).toEqual({ error: 'invalid-request' });
+    }
+  });
+
+  it('404s an unknown tile', async () => {
+    const { res, body } = await patchTile('no-such-tile', { verdict: 'approve' });
+    expect(res.status).toBe(404);
+    expect(body).toEqual({ error: 'not-found' });
+  });
+
+  it('409s an illegal transition (re-approving an approved tile)', async () => {
+    // The seeds are approved tiles — approving one again is illegal.
+    const approvedId = seedApprovedTiles()[0].id;
+    const { res, body } = await patchTile(approvedId, { verdict: 'approve' });
+    expect(res.status).toBe(409);
+    expect(body).toEqual({ error: 'invalid-transition' });
+  });
+
+  it('takes an approved tile down (reject) — and the wall stops serving it', async () => {
+    const approvedId = seedApprovedTiles()[0].id;
+    const { res } = await patchTile(approvedId, { verdict: 'reject' });
+    expect(res.status).toBe(200);
+    const wall = await getTileAdapters().repository.recentApproved(48);
+    expect(wall.map((t) => t.id)).not.toContain(approvedId);
+  });
+});

--- a/src/app/api/admin/tiles/[id]/route.ts
+++ b/src/app/api/admin/tiles/[id]/route.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+
+import { createTileService, type ModerateResult } from '@/lib/doodle-wall/tileService';
+import { getAdminIdentity } from '@/lib/supabase/adminAuth';
+import { getTileAdapters } from '@/lib/supabase/tileAdapters';
+
+/**
+ * PATCH /api/admin/tiles/:id — one verdict from the carny.
+ * Thin adapter: allow-list guard → parse → tileService.moderate (which owns
+ * transition legality). Body `{ verdict: 'approve' | 'reject' }`.
+ *
+ * Responses: 200 `{ id, status }`; errors as `{ error }` JSON — 401 signed
+ * out, 403 not the carny, 400 bad body, 404 unknown tile, 409 illegal
+ * transition, 503 pre-provisioning stub mode (nothing to moderate: the
+ * queue lives in per-instance memory and no one can sign in).
+ */
+export const runtime = 'nodejs';
+
+const BodySchema = z.object({
+  verdict: z.enum(['approve', 'reject']),
+});
+
+const FAILURE_STATUS: Record<Extract<ModerateResult, { ok: false }>['reason'], number> = {
+  'not-found': 404,
+  'invalid-transition': 409,
+};
+
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  // Same cross-site Origin rejection as POST /api/tiles: the session cookie
+  // is ambient authority, so a state-changing route refuses foreign origins
+  // outright rather than trusting SameSite defaults alone.
+  const origin = req.headers.get('origin');
+  const host = req.headers.get('host');
+  if (origin && host) {
+    try {
+      if (new URL(origin).host !== host) {
+        return Response.json({ error: 'bad-origin' }, { status: 403 });
+      }
+    } catch {
+      return Response.json({ error: 'bad-origin' }, { status: 403 });
+    }
+  }
+
+  const identity = await getAdminIdentity();
+  if (identity.kind === 'unconfigured') {
+    return Response.json({ error: 'unconfigured' }, { status: 503 });
+  }
+  if (identity.kind === 'anonymous') {
+    return Response.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  if (identity.kind === 'denied') {
+    return Response.json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: 'invalid-request' }, { status: 400 });
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) return Response.json({ error: 'invalid-request' }, { status: 400 });
+
+  const { id } = await ctx.params;
+  const service = createTileService(getTileAdapters());
+  const result = await service.moderate({ id, verdict: parsed.data.verdict });
+
+  if (!result.ok) {
+    return Response.json({ error: result.reason }, { status: FAILURE_STATUS[result.reason] });
+  }
+  return Response.json({ id: result.id, status: result.status });
+}

--- a/src/app/api/keepalive/route.test.ts
+++ b/src/app/api/keepalive/route.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetTileAdapters } from '@/lib/supabase/tileAdapters';
+
+import { GET } from './route';
+
+/** Keyless (stub mode) and offline, like the other route tests. */
+
+const keepalive = (headers: Record<string, string> = {}) =>
+  GET(new Request('http://localhost/api/keepalive', { headers }));
+
+beforeEach(() => {
+  vi.stubEnv('SUPABASE_URL', '');
+  vi.stubEnv('SUPABASE_ANON_KEY', '');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '');
+  vi.stubEnv('CRON_SECRET', '');
+  resetTileAdapters();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('GET /api/keepalive', () => {
+  it('touches the repository and reports stub mode when keyless', async () => {
+    const res = await keepalive();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, mode: 'stub' });
+  });
+
+  it('requires the bearer token when CRON_SECRET is set', async () => {
+    vi.stubEnv('CRON_SECRET', 'shhh');
+    expect((await keepalive()).status).toBe(401);
+    expect((await keepalive({ authorization: 'Bearer wrong' })).status).toBe(401);
+    expect((await keepalive({ authorization: 'Bearer shhh' })).status).toBe(200);
+  });
+});

--- a/src/app/api/keepalive/route.ts
+++ b/src/app/api/keepalive/route.ts
@@ -1,0 +1,35 @@
+import { Buffer } from 'node:buffer';
+import { timingSafeEqual } from 'node:crypto';
+
+import { getTileAdapters } from '@/lib/supabase/tileAdapters';
+
+/**
+ * GET /api/keepalive — the daily cron's touch (vercel.json) so the
+ * free-tier Supabase project registers activity and is never paused for
+ * inactivity. One bounded read through the repository port; in stub mode
+ * it touches the fakes and reports so.
+ *
+ * When CRON_SECRET is set, callers must present it (Vercel sends
+ * `Authorization: Bearer <CRON_SECRET>` automatically); without the env the
+ * route is open — it reads one approved tile, the same data /api/wall
+ * already serves the world.
+ */
+export const runtime = 'nodejs';
+
+export async function GET(req: Request): Promise<Response> {
+  const secret = process.env.CRON_SECRET;
+  if (secret && !bearerMatches(req.headers.get('authorization'), secret)) {
+    return Response.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const adapters = getTileAdapters();
+  await adapters.repository.recentApproved(1);
+  return Response.json({ ok: true, mode: adapters.live ? 'live' : 'stub' });
+}
+
+/** Constant-time bearer check — string !== leaks a per-character timing signal. */
+function bearerMatches(header: string | null, secret: string): boolean {
+  const presented = Buffer.from(header ?? '');
+  const expected = Buffer.from(`Bearer ${secret}`);
+  return presented.length === expected.length && timingSafeEqual(presented, expected);
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -7,6 +7,9 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
+      // The carny's counter and the API surface aren't content (Stage 2 also
+      // sets robots noindex metadata on /admin itself).
+      disallow: ['/admin', '/api/'],
     },
     sitemap: `${SITE_URL}/sitemap.xml`,
   };

--- a/src/lib/doodle-wall/constants.ts
+++ b/src/lib/doodle-wall/constants.ts
@@ -31,3 +31,11 @@ export const SUBMIT_BURST_PER_MINUTE = 2;
 
 /** Daily cap: submissions per submitter hash per rolling 24 h (durable). */
 export const SUBMIT_DAILY_CAP = 10;
+
+/** Upper bound on pending tiles per pre-moderation-queue load (/admin). */
+export const QUEUE_PAGE_COUNT = 48;
+
+// NB: the carny's allow-list (MODERATOR_EMAILS) deliberately does NOT live
+// here — this module is re-exported by the client-shipped doodleWallConfig,
+// and the auth boundary should be structural, not tree-shaking luck. It
+// lives in src/lib/supabase/adminAuth.ts, a server-only module.

--- a/src/lib/doodle-wall/fakes.ts
+++ b/src/lib/doodle-wall/fakes.ts
@@ -4,7 +4,7 @@ import { deflateSync } from 'node:zlib';
 
 import { STORED_TILE_SIZE } from './constants';
 import type { TileImageStore, TileRepository } from './ports';
-import type { Tile } from './types';
+import type { Tile, TileStatus } from './types';
 
 /**
  * In-memory adapters for the doodle wall ports — what dev, CI, and a
@@ -169,6 +169,24 @@ export class InMemoryTileRepository implements TileRepository {
       (tile) => tile.submitterHash === submitterHash && tile.createdAt >= sinceIso,
     ).length;
     return Promise.resolve(count);
+  }
+
+  oldestPending(limit: number): Promise<Tile[]> {
+    const pending = this.tiles
+      .filter((tile) => tile.status === 'pending')
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+      .slice(0, limit);
+    return Promise.resolve(pending);
+  }
+
+  findById(id: string): Promise<Tile | null> {
+    return Promise.resolve(this.tiles.find((tile) => tile.id === id) ?? null);
+  }
+
+  setStatus(id: string, status: TileStatus): Promise<void> {
+    const tile = this.tiles.find((t) => t.id === id);
+    if (tile) tile.status = status;
+    return Promise.resolve();
   }
 
   /** Test/stub inspection — deliberately not part of the port. */

--- a/src/lib/doodle-wall/ports.ts
+++ b/src/lib/doodle-wall/ports.ts
@@ -1,4 +1,4 @@
-import type { Tile } from './types';
+import type { Tile, TileStatus } from './types';
 
 /**
  * Ports the tileService depends on — one interface per dependency direction.
@@ -17,6 +17,17 @@ export interface TileRepository {
    * instance churn.
    */
   countSubmittedSince(submitterHash: string, sinceIso: string): Promise<number>;
+  /** Oldest-first pending tiles, at most `limit` — the pre-moderation queue (FIFO). */
+  oldestPending(limit: number): Promise<Tile[]>;
+  /** One tile by id, any status; null when absent. */
+  findById(id: string): Promise<Tile | null>;
+  /**
+   * Persist a status transition. The Supabase adapter also maintains
+   * approved_at (set on approve, cleared otherwise) — a column the domain
+   * Tile deliberately doesn't carry. Transition legality is the service's
+   * rule, not the repository's.
+   */
+  setStatus(id: string, status: TileStatus): Promise<void>;
 }
 
 export interface TileImageStore {

--- a/src/lib/doodle-wall/tileService.test.ts
+++ b/src/lib/doodle-wall/tileService.test.ts
@@ -131,6 +131,90 @@ describe('tileService.getWall', () => {
   });
 });
 
+describe('tileService.getQueue', () => {
+  it('returns pending tiles oldest-first, projected to the public shape', async () => {
+    const base = Date.parse('2026-07-01T00:00:00Z');
+    repository = new InMemoryTileRepository([
+      makeStoredTile({ status: 'pending', createdAt: new Date(base + 2000).toISOString() }),
+      makeStoredTile({ status: 'approved', createdAt: new Date(base + 1000).toISOString() }),
+      makeStoredTile({ status: 'pending', createdAt: new Date(base).toISOString() }),
+      makeStoredTile({ status: 'rejected', createdAt: new Date(base + 3000).toISOString() }),
+    ]);
+    service = createTileService({ repository, imageStore: new InMemoryTileImageStore() });
+
+    const queue = await service.getQueue();
+    expect(queue.map((t) => t.createdAt)).toEqual([
+      new Date(base).toISOString(),
+      new Date(base + 2000).toISOString(),
+    ]);
+    // Projection: nothing beyond the public shape leaves the domain.
+    expect(Object.keys(queue[0]).sort()).toEqual(['createdAt', 'id', 'imageUrl']);
+  });
+
+  it(`is bounded at QUEUE_PAGE_COUNT`, async () => {
+    const { QUEUE_PAGE_COUNT } = await import('./constants');
+    repository = new InMemoryTileRepository(
+      Array.from({ length: QUEUE_PAGE_COUNT + 5 }, () => makeStoredTile({ status: 'pending' })),
+    );
+    service = createTileService({ repository, imageStore: new InMemoryTileImageStore() });
+    expect(await service.getQueue()).toHaveLength(QUEUE_PAGE_COUNT);
+  });
+});
+
+describe('tileService.moderate', () => {
+  const withTile = (status: Tile['status']) => {
+    const tile = makeStoredTile({ status });
+    repository = new InMemoryTileRepository([tile]);
+    service = createTileService({ repository, imageStore: new InMemoryTileImageStore() });
+    return tile;
+  };
+
+  it('approves a pending tile', async () => {
+    const tile = withTile('pending');
+    const result = await service.moderate({ id: tile.id, verdict: 'approve' });
+    expect(result).toEqual({ ok: true, id: tile.id, status: 'approved' });
+    expect((await repository.findById(tile.id))?.status).toBe('approved');
+  });
+
+  it('rejects a pending tile', async () => {
+    const tile = withTile('pending');
+    const result = await service.moderate({ id: tile.id, verdict: 'reject' });
+    expect(result).toEqual({ ok: true, id: tile.id, status: 'rejected' });
+  });
+
+  it('takes an approved tile back down (approved → rejected)', async () => {
+    const tile = withTile('approved');
+    const result = await service.moderate({ id: tile.id, verdict: 'reject' });
+    expect(result).toEqual({ ok: true, id: tile.id, status: 'rejected' });
+  });
+
+  it('refuses to re-approve an approved tile', async () => {
+    const tile = withTile('approved');
+    expect(await service.moderate({ id: tile.id, verdict: 'approve' })).toEqual({
+      ok: false,
+      reason: 'invalid-transition',
+    });
+  });
+
+  it('refuses any verdict on a rejected tile — rejection is final', async () => {
+    const tile = withTile('rejected');
+    for (const verdict of ['approve', 'reject'] as const) {
+      expect(await service.moderate({ id: tile.id, verdict })).toEqual({
+        ok: false,
+        reason: 'invalid-transition',
+      });
+    }
+  });
+
+  it('reports an unknown id as not-found', async () => {
+    withTile('pending');
+    expect(await service.moderate({ id: 'no-such-tile', verdict: 'approve' })).toEqual({
+      ok: false,
+      reason: 'not-found',
+    });
+  });
+});
+
 let tileCounter = 0;
 
 function makeStoredTile(overrides: Partial<Tile>): Tile {

--- a/src/lib/doodle-wall/tileService.ts
+++ b/src/lib/doodle-wall/tileService.ts
@@ -1,9 +1,15 @@
 import { randomUUID } from 'node:crypto';
 
-import { STORED_TILE_SIZE, SUBMIT_DAILY_CAP, TILE_MAX_BYTES, WALL_TILE_COUNT } from './constants';
+import {
+  QUEUE_PAGE_COUNT,
+  STORED_TILE_SIZE,
+  SUBMIT_DAILY_CAP,
+  TILE_MAX_BYTES,
+  WALL_TILE_COUNT,
+} from './constants';
 import { readPngDimensions } from './png';
 import type { TileImageStore, TileRepository } from './ports';
-import type { Tile, WallTile } from './types';
+import type { Tile, TileStatus, WallTile } from './types';
 
 /**
  * The doodle wall's submit and wall rules, pure of HTTP and of Supabase.
@@ -14,6 +20,24 @@ import type { Tile, WallTile } from './types';
 export type SubmitTileResult =
   { ok: true; tile: Tile } | { ok: false; reason: 'invalid-image' | 'too-large' | 'daily-cap' };
 
+/** The carny's ruling on a queued tile (CONTEXT.md: Verdict). */
+export type Verdict = 'approve' | 'reject';
+
+export type ModerateResult =
+  | { ok: true; id: string; status: TileStatus }
+  | { ok: false; reason: 'not-found' | 'invalid-transition' };
+
+/**
+ * Legal verdict transitions (Stage 2): the carny approves or rejects
+ * pending tiles, and may take an approved tile back down (reject it) if one
+ * turns sour after the fact. A rejected tile stays rejected — restoring one
+ * is deliberately not a thing (resubmit instead).
+ */
+const VERDICT_FROM: Record<Verdict, readonly TileStatus[]> = {
+  approve: ['pending'],
+  reject: ['pending', 'approved'],
+};
+
 export interface TileService {
   submitTile(input: { imageBytes: Uint8Array; submitterHash: string }): Promise<SubmitTileResult>;
   /**
@@ -21,9 +45,24 @@ export interface TileService {
    * already projected to the public WallTile shape.
    */
   getWall(): Promise<WallTile[]>;
+  /**
+   * The pre-moderation queue: oldest-first (first drawn, first reviewed),
+   * bounded at QUEUE_PAGE_COUNT, projected like the wall — the carny's
+   * counter needs nothing the public shape doesn't carry.
+   */
+  getQueue(): Promise<WallTile[]>;
+  /** Apply one verdict; transition legality enforced here. */
+  moderate(input: { id: string; verdict: Verdict }): Promise<ModerateResult>;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The public projection — THE privacy boundary at the domain edge: no
+ * submitterHash, no imagePath, applied once here so no consumer (wall or
+ * queue) can forget to strip them.
+ */
+const toWallTile = ({ id, imageUrl, createdAt }: Tile): WallTile => ({ id, imageUrl, createdAt });
 
 export function createTileService(deps: {
   repository: TileRepository;
@@ -81,10 +120,27 @@ export function createTileService(deps: {
     },
 
     async getWall() {
-      // Public projection at the domain boundary: submitterHash and imagePath
-      // must never depend on each consumer remembering to strip them.
       const tiles = await repository.recentApproved(WALL_TILE_COUNT);
-      return tiles.map(({ id, imageUrl, createdAt }) => ({ id, imageUrl, createdAt }));
+      return tiles.map(toWallTile);
+    },
+
+    async getQueue() {
+      const tiles = await repository.oldestPending(QUEUE_PAGE_COUNT);
+      return tiles.map(toWallTile);
+    },
+
+    async moderate({ id, verdict }) {
+      const tile = await repository.findById(id);
+      if (!tile) return { ok: false, reason: 'not-found' };
+      if (!VERDICT_FROM[verdict].includes(tile.status)) {
+        return { ok: false, reason: 'invalid-transition' };
+      }
+      // Read-then-write, not compare-and-set: there is exactly one carny, so
+      // the race this admits (two verdicts on the same tile crossing) needs
+      // two of him. Same trade as the daily cap's count-then-insert.
+      const status: TileStatus = verdict === 'approve' ? 'approved' : 'rejected';
+      await repository.setStatus(id, status);
+      return { ok: true, id, status };
     },
   };
 }

--- a/src/lib/supabase/adminAuth.test.ts
+++ b/src/lib/supabase/adminAuth.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { isModeratorEmail, MODERATOR_EMAILS } from './adminAuth';
+
+describe('isModeratorEmail — the carny allow-list', () => {
+  it('admits every allow-listed email, case- and whitespace-insensitively', () => {
+    for (const email of MODERATOR_EMAILS) {
+      expect(isModeratorEmail(email)).toBe(true);
+      expect(isModeratorEmail(email.toUpperCase())).toBe(true);
+      expect(isModeratorEmail(`  ${email} `)).toBe(true);
+    }
+  });
+
+  it('denies everyone else — including lookalikes', () => {
+    expect(isModeratorEmail('mallory@iamnick.dev')).toBe(false);
+    expect(isModeratorEmail('nick@iamnick.dev.evil.example')).toBe(false);
+    expect(isModeratorEmail('nick+admin@iamnick.dev')).toBe(false);
+    expect(isModeratorEmail('')).toBe(false);
+  });
+
+  it('is a hard allow-list of exactly one account (ADR-0001)', () => {
+    expect(MODERATOR_EMAILS).toHaveLength(1);
+  });
+});

--- a/src/lib/supabase/adminAuth.ts
+++ b/src/lib/supabase/adminAuth.ts
@@ -1,0 +1,119 @@
+import { cookies } from 'next/headers';
+import { createServerClient as createSsrClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { SITE_URL } from '@/lib/site';
+
+/**
+ * Admin (carny) authentication for /admin — Supabase Auth with Google OAuth
+ * and the HARD allow-list below (ADR-0001: Nick's account only).
+ *
+ * The whole flow is server-side: the anon key builds a cookie-session client
+ * here (route handlers + server components), so no Supabase key or client
+ * ever reaches the browser bundle. Identity checks use getClaims(), which
+ * verifies the JWT signature against the project's JWKS — never getSession's
+ * unvalidated user object (cookies are attacker-supplied input).
+ *
+ * No auth middleware/proxy: /admin is one page for one person. An expired
+ * access token in a server-component render simply reads as signed-out and
+ * offers the sign-in button again; route handlers CAN write cookies, so any
+ * refresh that happens there persists.
+ */
+
+/**
+ * The carny's identity — the HARD allow-list for /admin (ADR-0001: Nick's
+ * account only, never widened to "any Google login"). Lives in this
+ * server-only module (not doodle-wall/constants.ts) so it is structurally
+ * unreachable from the client bundle. Compared lowercased against the email
+ * claim, and only for sessions whose provider is Google (app_metadata is
+ * server-controlled; user_metadata is user-editable and never consulted).
+ */
+export const MODERATOR_EMAILS: readonly string[] = ['nick@iamnick.dev'];
+
+export type AdminIdentity =
+  /** Supabase env absent — pre-provisioning stub mode, /admin is inert. */
+  | { kind: 'unconfigured' }
+  | { kind: 'anonymous' }
+  /** Signed in with Google, but not the carny. */
+  | { kind: 'denied'; email: string }
+  | { kind: 'moderator'; email: string };
+
+/** Pure allow-list rule, unit-testable without any Supabase machinery. */
+export function isModeratorEmail(email: string): boolean {
+  const normalised = email.trim().toLowerCase();
+  return MODERATOR_EMAILS.some((allowed) => allowed.toLowerCase() === normalised);
+}
+
+/**
+ * ONE configured-predicate with getTileAdapters: all three Supabase vars or
+ * stub. The auth client itself only needs URL + anon key, but treating a
+ * partial env as "configured" here while the adapters call it stub would let
+ * the carny sign in over an in-memory fake queue mid-provisioning.
+ */
+function isSupabaseConfigured(): boolean {
+  return Boolean(
+    process.env.SUPABASE_URL &&
+    process.env.SUPABASE_ANON_KEY &&
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+}
+
+/**
+ * Cookie-session Supabase client for the current request, or null in stub
+ * mode. A new client per request — it's a fetch configuration, not a
+ * connection (and the cookie jar differs per request).
+ */
+export async function createAdminAuthClient(): Promise<SupabaseClient | null> {
+  if (!isSupabaseConfigured()) return null;
+
+  const cookieStore = await cookies();
+  return createSsrClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!, {
+    cookies: {
+      getAll: () => cookieStore.getAll(),
+      setAll: (cookiesToSet) => {
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // Server Components cannot write cookies; token refreshes persist
+          // when they happen in a route handler instead.
+        }
+      },
+    },
+  });
+}
+
+/**
+ * The origin the auth redirects (and OAuth redirectTo) are built against.
+ * In production this is pinned to SITE_URL — x-forwarded-* headers are
+ * request input and must never steer a redirect target. Elsewhere (dev,
+ * previews) the request URL's own origin is what the visitor actually hit.
+ */
+export function requestOrigin(req: Request): string {
+  if (process.env.VERCEL_ENV === 'production') return SITE_URL;
+  return new URL(req.url).origin;
+}
+
+/** Who is at the carny's counter this request? */
+export async function getAdminIdentity(): Promise<AdminIdentity> {
+  const client = await createAdminAuthClient();
+  if (!client) return { kind: 'unconfigured' };
+
+  const { data } = await client.auth.getClaims();
+  const claims = data?.claims;
+  const email = claims?.email;
+  if (typeof email !== 'string' || email.length === 0) return { kind: 'anonymous' };
+
+  // Provider pin: the allow-list's security model is "Google vouched for
+  // this mailbox". A session minted any other way (e.g. email/password
+  // signup claiming the carny's address, should that provider ever be
+  // enabled) must never pass, however its email claim reads. app_metadata
+  // is set by the auth server, not the user.
+  const appMetadata = claims?.app_metadata as { provider?: string; providers?: string[] } | null;
+  const viaGoogle =
+    appMetadata?.provider === 'google' || (appMetadata?.providers ?? []).includes('google');
+  if (!viaGoogle) return { kind: 'denied', email };
+
+  return isModeratorEmail(email) ? { kind: 'moderator', email } : { kind: 'denied', email };
+}

--- a/src/lib/supabase/tileAdapters.ts
+++ b/src/lib/supabase/tileAdapters.ts
@@ -22,6 +22,8 @@ export interface TileAdapters {
   repository: TileRepository;
   imageStore: TileImageStore;
   submitterHashSecret: string;
+  /** true = real Supabase; false = in-memory stub mode. */
+  live: boolean;
 }
 
 /**
@@ -58,6 +60,7 @@ export function getTileAdapters(): TileAdapters {
     return {
       ...fakes,
       submitterHashSecret: process.env.SUBMITTER_HASH_SECRET || DEV_SUBMITTER_HASH_SECRET,
+      live: false,
     };
   }
 
@@ -77,7 +80,7 @@ export function getTileAdapters(): TileAdapters {
       imageStore: new SupabaseTileImageStore(client),
     };
   }
-  return { ...supabase, submitterHashSecret };
+  return { ...supabase, submitterHashSecret, live: true };
 }
 
 /** Test hook: drop the singletons so each case starts from the seed. */

--- a/src/lib/supabase/tileRepository.ts
+++ b/src/lib/supabase/tileRepository.ts
@@ -58,6 +58,40 @@ export class SupabaseTileRepository implements TileRepository {
     return count ?? 0;
   }
 
+  async oldestPending(limit: number): Promise<Tile[]> {
+    const { data, error } = await this.client
+      .from('tiles')
+      .select(TILE_COLUMNS)
+      .eq('status', 'pending')
+      .order('created_at', { ascending: true })
+      .limit(limit);
+    if (error) throw new Error(`[doodle-wall] queue query failed: ${error.message}`);
+    return ((data ?? []) as TileRow[]).map((row) => this.toTile(row));
+  }
+
+  async findById(id: string): Promise<Tile | null> {
+    const { data, error } = await this.client
+      .from('tiles')
+      .select(TILE_COLUMNS)
+      .eq('id', id)
+      .maybeSingle();
+    // 22P02 = invalid uuid syntax: a malformed id is "no such tile" (the
+    // fakes return null too), not a 500 — the column is uuid-typed.
+    if (error?.code === '22P02') return null;
+    if (error) throw new Error(`[doodle-wall] tile lookup failed: ${error.message}`);
+    return data ? this.toTile(data as TileRow) : null;
+  }
+
+  async setStatus(id: string, status: TileStatus): Promise<void> {
+    // approved_at lives only in the database (the domain Tile doesn't carry
+    // it): set on approve, cleared on any other transition.
+    const { error } = await this.client
+      .from('tiles')
+      .update({ status, approved_at: status === 'approved' ? new Date().toISOString() : null })
+      .eq('id', id);
+    if (error) throw new Error(`[doodle-wall] status update failed: ${error.message}`);
+  }
+
   private toTile(row: TileRow): Tile {
     // getPublicUrl is a synchronous URL construction — no network call.
     const { data } = this.client.storage.from(TILES_BUCKET).getPublicUrl(row.image_path);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/keepalive",
+      "schedule": "0 8 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Stage 2 of the doodle wall (ADR-0001): moderation. Contracts from the handoff §2.1 were built against, not renegotiated.

## What's in

- **Domain** — `tileService.getQueue()` (pre-moderation queue: oldest-first, bounded at 48, projected through a single shared privacy boundary) and `tileService.moderate({id, verdict})` with the transition rules: approve `pending→approved`; reject `pending|approved→rejected` (takedown supported); **rejected is final**. Port + Supabase adapter + fakes extended (`approved_at` maintained adapter-side; malformed uuids read as not-found, never 500).
- **Auth (`src/lib/supabase/adminAuth.ts`, server-only)** — Google OAuth via `@supabase/ssr` cookie sessions, entirely server-side: **no Supabase key or client ever reaches the browser bundle**. Identity via `getClaims()` (JWKS-verified), **hard allow-list** of `nick@iamnick.dev`, **provider pinned to Google** (an email/password account claiming the same address can never pass), production redirects pinned to `SITE_URL` (no `x-forwarded-host` trust).
- **Routes** — `/api/admin/auth/{login,callback,logout}`; `PATCH /api/admin/tiles/:id` body `{verdict}` → `200 {id,status}` / `{error}` 400·401·403(+bad-origin)·404·409·503, with the same cross-site Origin rejection as `POST /api/tiles`; `GET /api/keepalive` (+ `vercel.json` daily cron, timing-safe optional `CRON_SECRET`).
- **UI** — `/admin`, **the carny's counter** (new CONTEXT.md entries: *the carny's counter*, *verdict*; the carny entry widened — Nick *is* the carny at the counter). Four states (stub/signed-out/denied/moderator), phone-first letterpress cards, noindex + robots disallow. Verdict cards drop only on tile-level reasons — a platform 404 mid-deploy can't silently eat verdicts — and `router.refresh()` remounts the list by key so it actually refreshes.

## Close-out chain (per the handoff)

glossary-guard → 5 findings (booth→counter, verdict canonized, pre-moderation-queue drift, carny scope widened) — all resolved. `/code-review` high → 24 candidates, **10 confirmed and fixed** in this PR (queue-refresh no-op, provider pin, forwarded-host trust, timing-safe secret compare, blind 404 drop, configured-predicate disagreement, uuid 500, missing Origin check, duplicated projection, allow-list moved out of the client-reachable module). 5 new parked follow-ons recorded in the handoff §5.

Gate: typecheck ✓ · lint ✓ · **149 tests** ✓ · build ✓. Stub-mode `/admin` smoke-verified by screenshot.

## Nick's config gate (before /admin works — nothing here needs code)

1. **Google Cloud Console** → create an OAuth web client; Authorized redirect URI: `https://hzwjezozoxlopyfgmxoc.supabase.co/auth/v1/callback`
2. **Supabase → Auth → Providers → Google**: enable, paste client ID + secret (secrets go in the dashboard only — never in chat/repo)
3. **Supabase → Auth → URL Configuration**: Site URL `https://iamnick.dev`; redirect allow-list `https://iamnick.dev/api/admin/auth/callback` and `http://localhost:3000/api/admin/auth/callback`
4. Recommended: **disable the email/password provider** (the provider pin already blocks it; defense in depth)
5. Optional: set `CRON_SECRET` in Vercel
6. Then the e2e: sign in on your phone → pending tile appears → approve → it's on the wall; a non-allow-listed Google account gets the denied card

🤖 Generated with [Claude Code](https://claude.com/claude-code)