### PR TITLE
Blog Stage 1 — Velite content pipeline + typed layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Validate env schema
         run: pnpm env:check
 
+      - name: Build content layer (velite)
+        run: pnpm content
+
       - name: Lint
         run: pnpm lint
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ pnpm-debug.log*
 # TS
 *.tsbuildinfo
 
+# velite (blog content pipeline) generated output
+.velite/
+
 # Claude Code agent worktrees / local
 .claude/worktrees/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .next
+.velite
 node_modules
 public
 coverage

--- a/content/blog/building-this-blog-in-the-open.mdx
+++ b/content/blog/building-this-blog-in-the-open.mdx
@@ -1,0 +1,26 @@
+---
+title: Building this blog in the open
+description: First entry in the build journal — how this blog is being specced and built with agentic workflows, decisions recorded as they happen.
+date: 2026-07-17
+tags: ['agentic-workflows', 'meta']
+slug: building-this-blog-in-the-open
+---
+
+This blog documents its own construction. Before any of these pages existed there was a
+spec set — a discovery doc with a numbered decision log, a PRD, four architecture
+decision records and a designed delivery workflow — written with an AI pair and ruled on
+by me.
+
+The content pipeline behind this page is deliberately boring: MDX files in the repo,
+compiled at build time, with schema-validated frontmatter. If a post's metadata is
+wrong, the build fails:
+
+```ts
+description: s.string().min(10).max(160),
+date: s.isodate(),
+draft: s.boolean().default(false),
+```
+
+The interesting part is the process around it — sub-agents that keep context between
+sessions, review passes that catch what I miss, and a publish pipeline where the AI
+edits but never ghost-writes. Those are the stories this journal is for.

--- a/content/blog/designing-the-publish-pipeline.mdx
+++ b/content/blog/designing-the-publish-pipeline.mdx
@@ -1,0 +1,18 @@
+---
+title: Designing the publish pipeline
+description: Draft notes on the /publish-post editorial pipeline — the passes, the human gates, and the mechanisms that were rejected as over-engineering.
+date: 2026-07-16
+draft: true
+tags: ['agentic-workflows']
+slug: designing-the-publish-pipeline
+---
+
+Draft notes, to be written up properly once the pipeline has shipped a real post.
+
+The shape so far: a structural pass fails fast on metadata, a read-only reviewer
+fact-checks every claim against the repo, a voice pass strips the AI tells, and nothing
+publishes until I have read the edited draft and merged the PR myself.
+
+The rejected alternatives are the more interesting half — an orchestrating editor agent
+(cannot pause for a human mid-flow), scheduled publishing loops (cadence is
+human-paced), and automated journals (judgment does not automate).

--- a/docs/blog/journal.md
+++ b/docs/blog/journal.md
@@ -21,3 +21,14 @@ available, the boards were built as real rendered HTML screenshotted through Pla
 constraint turned out better than the intended mockups, because the winning board's CSS is now the
 literal token source rather than a picture to be reverse-engineered. Owed before Stage 2 ships: a
 monogram distinctiveness pass at small sizes.
+
+**2026-07-17 — Stage 1, content pipeline.** The stage was mechanical exactly as designed — the
+specs had absorbed all the thinking, so the build was transcription: velite, the Zod frontmatter
+contract, `publishedPosts` as the single public read, tests beside it, gate green on the first
+full run (162 tests). Both surprises were toolchain seams, not design. First, pnpm 11's
+build-scripts gate nobody had tripped yet: a placeholder line under `allowBuilds` in
+`pnpm-workspace.yaml` blocked esbuild — velite's transitive dep — and broke `pnpm exec` outright
+until set to a real value. Second, the discovery that repo-wide prettier and lint-staged disagree
+about HTML: the Stage B brand boards slipped through unformatted and turned master red on the
+PR #72 merge — found within the hour and fixed in the next PR. One quiet win: the two seed Posts
+mean every later stage tests against real content, not fixtures.

--- a/docs/brand/boards/concept-a-whoami.html
+++ b/docs/brand/boards/concept-a-whoami.html
@@ -1,175 +1,357 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<title>iamnick — Concept A — whoami</title>
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-<style>
-  /* ---- Concept A token source ---- */
-  :root {
-    --a-ink: #0e0f11;        /* base — warm-grey ink, NOT carnival blue-black */
-    --a-panel: #16181b;
-    --a-paper: #f2f0eb;      /* text on ink */
-    --a-muted: #8b8f94;
-    --a-accent: #58c4dc;     /* signal cyan — the only accent */
-    --a-hairline: #26292d;
-    --a-display: 'Space Grotesk', sans-serif;
-    --a-text: 'Inter', sans-serif;
-    --a-mono: 'JetBrains Mono', monospace;
-  }
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body {
-    width: 1600px; height: 1200px;
-    background: #0a0b0c;
-    font-family: var(--a-text);
-    color: var(--a-paper);
-    padding: 48px 56px 40px;
-    display: flex; flex-direction: column;
-  }
-  header {
-    display: flex; justify-content: space-between; align-items: baseline;
-    font-family: var(--a-mono); font-size: 12px; letter-spacing: .14em;
-    color: var(--a-muted); text-transform: uppercase; padding-bottom: 28px;
-  }
-  header .acc { color: var(--a-accent); }
-  .grid {
-    flex: 1; display: grid; grid-template-columns: 1.35fr 1fr 1fr;
-    grid-template-rows: 1.25fr 1fr; gap: 22px;
-  }
-  .panel {
-    background: var(--a-panel); border: 1px solid var(--a-hairline);
-    border-radius: 10px; padding: 36px; position: relative; overflow: hidden;
-  }
-  .label {
-    position: absolute; top: 18px; left: 22px;
-    font-family: var(--a-mono); font-size: 10px; letter-spacing: .2em;
-    color: var(--a-muted); text-transform: uppercase;
-  }
-  .num { left: auto; right: 22px; }
+  <head>
+    <meta charset="utf-8" />
+    <title>iamnick — Concept A — whoami</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ---- Concept A token source ---- */
+      :root {
+        --a-ink: #0e0f11; /* base — warm-grey ink, NOT carnival blue-black */
+        --a-panel: #16181b;
+        --a-paper: #f2f0eb; /* text on ink */
+        --a-muted: #8b8f94;
+        --a-accent: #58c4dc; /* signal cyan — the only accent */
+        --a-hairline: #26292d;
+        --a-display: 'Space Grotesk', sans-serif;
+        --a-text: 'Inter', sans-serif;
+        --a-mono: 'JetBrains Mono', monospace;
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        width: 1600px;
+        height: 1200px;
+        background: #0a0b0c;
+        font-family: var(--a-text);
+        color: var(--a-paper);
+        padding: 48px 56px 40px;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        font-family: var(--a-mono);
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        color: var(--a-muted);
+        text-transform: uppercase;
+        padding-bottom: 28px;
+      }
+      header .acc {
+        color: var(--a-accent);
+      }
+      .grid {
+        flex: 1;
+        display: grid;
+        grid-template-columns: 1.35fr 1fr 1fr;
+        grid-template-rows: 1.25fr 1fr;
+        gap: 22px;
+      }
+      .panel {
+        background: var(--a-panel);
+        border: 1px solid var(--a-hairline);
+        border-radius: 10px;
+        padding: 36px;
+        position: relative;
+        overflow: hidden;
+      }
+      .label {
+        position: absolute;
+        top: 18px;
+        left: 22px;
+        font-family: var(--a-mono);
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        color: var(--a-muted);
+        text-transform: uppercase;
+      }
+      .num {
+        left: auto;
+        right: 22px;
+      }
 
-  /* 1 — logo cover */
-  .cover { grid-column: 1; grid-row: 1; background: var(--a-ink);
-    display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 34px; }
-  .cover .word { font-family: var(--a-display); font-size: 58px; font-weight: 700; letter-spacing: -0.02em; }
-  .cover .word .dim { color: var(--a-muted); font-weight: 400; }
-  .cover .word .dot { color: var(--a-accent); }
+      /* 1 — logo cover */
+      .cover {
+        grid-column: 1;
+        grid-row: 1;
+        background: var(--a-ink);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 34px;
+      }
+      .cover .word {
+        font-family: var(--a-display);
+        font-size: 58px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+      .cover .word .dim {
+        color: var(--a-muted);
+        font-weight: 400;
+      }
+      .cover .word .dot {
+        color: var(--a-accent);
+      }
 
-  /* 2 — product surface */
-  .browser { grid-column: 2 / 4; grid-row: 1; display: flex; flex-direction: column; padding: 0; }
-  .chrome { display: flex; align-items: center; gap: 14px; padding: 16px 22px;
-    border-bottom: 1px solid var(--a-hairline); }
-  .dots span { display: inline-block; width: 9px; height: 9px; border-radius: 50%;
-    background: #2e3237; margin-right: 5px; }
-  .url { flex: 1; background: var(--a-ink); border: 1px solid var(--a-hairline); border-radius: 6px;
-    font-family: var(--a-mono); font-size: 12.5px; color: var(--a-muted); padding: 8px 14px; }
-  .url b { color: var(--a-paper); font-weight: 500; }
-  .post { padding: 44px 52px; }
-  .post .meta { font-family: var(--a-mono); font-size: 12.5px; color: var(--a-accent);
-    letter-spacing: .08em; margin-bottom: 18px; }
-  .post .meta span { color: var(--a-muted); }
-  .post h1 { font-family: var(--a-display); font-size: 40px; font-weight: 700;
-    letter-spacing: -0.02em; line-height: 1.12; margin-bottom: 18px; }
-  .post p { font-size: 16.5px; line-height: 1.65; color: #c9c7c1; max-width: 58ch; }
+      /* 2 — product surface */
+      .browser {
+        grid-column: 2 / 4;
+        grid-row: 1;
+        display: flex;
+        flex-direction: column;
+        padding: 0;
+      }
+      .chrome {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 16px 22px;
+        border-bottom: 1px solid var(--a-hairline);
+      }
+      .dots span {
+        display: inline-block;
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: #2e3237;
+        margin-right: 5px;
+      }
+      .url {
+        flex: 1;
+        background: var(--a-ink);
+        border: 1px solid var(--a-hairline);
+        border-radius: 6px;
+        font-family: var(--a-mono);
+        font-size: 12.5px;
+        color: var(--a-muted);
+        padding: 8px 14px;
+      }
+      .url b {
+        color: var(--a-paper);
+        font-weight: 500;
+      }
+      .post {
+        padding: 44px 52px;
+      }
+      .post .meta {
+        font-family: var(--a-mono);
+        font-size: 12.5px;
+        color: var(--a-accent);
+        letter-spacing: 0.08em;
+        margin-bottom: 18px;
+      }
+      .post .meta span {
+        color: var(--a-muted);
+      }
+      .post h1 {
+        font-family: var(--a-display);
+        font-size: 40px;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        line-height: 1.12;
+        margin-bottom: 18px;
+      }
+      .post p {
+        font-size: 16.5px;
+        line-height: 1.65;
+        color: #c9c7c1;
+        max-width: 58ch;
+      }
 
-  /* 3 — terminal */
-  .term { grid-column: 1; grid-row: 2; background: var(--a-ink);
-    font-family: var(--a-mono); font-size: 17px; line-height: 2.05;
-    display: flex; flex-direction: column; justify-content: center; padding-left: 48px; }
-  .term .ps { color: var(--a-accent); }
-  .term .out { color: var(--a-paper); }
-  .term .cmt { color: var(--a-muted); }
-  .cursor { display: inline-block; width: 10px; height: 20px; background: var(--a-accent);
-    vertical-align: text-bottom; margin-left: 2px; }
+      /* 3 — terminal */
+      .term {
+        grid-column: 1;
+        grid-row: 2;
+        background: var(--a-ink);
+        font-family: var(--a-mono);
+        font-size: 17px;
+        line-height: 2.05;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding-left: 48px;
+      }
+      .term .ps {
+        color: var(--a-accent);
+      }
+      .term .out {
+        color: var(--a-paper);
+      }
+      .term .cmt {
+        color: var(--a-muted);
+      }
+      .cursor {
+        display: inline-block;
+        width: 10px;
+        height: 20px;
+        background: var(--a-accent);
+        vertical-align: text-bottom;
+        margin-left: 2px;
+      }
 
-  /* 4 — construction */
-  .construct { grid-column: 2; grid-row: 2;
-    display: flex; align-items: center; justify-content: center; }
+      /* 4 — construction */
+      .construct {
+        grid-column: 2;
+        grid-row: 2;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  /* 5 — tagline */
-  .tag { grid-column: 3; grid-row: 2; background: var(--a-ink);
-    display: flex; flex-direction: column; justify-content: center; padding: 44px; gap: 22px; }
-  .tag h2 { font-family: var(--a-display); font-size: 34px; font-weight: 500;
-    letter-spacing: -0.01em; line-height: 1.25; }
-  .tag h2 em { font-style: normal; color: var(--a-accent); }
-  .swatches { display: flex; gap: 10px; }
-  .sw { width: 44px; height: 44px; border-radius: 7px; border: 1px solid var(--a-hairline); }
+      /* 5 — tagline */
+      .tag {
+        grid-column: 3;
+        grid-row: 2;
+        background: var(--a-ink);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding: 44px;
+        gap: 22px;
+      }
+      .tag h2 {
+        font-family: var(--a-display);
+        font-size: 34px;
+        font-weight: 500;
+        letter-spacing: -0.01em;
+        line-height: 1.25;
+      }
+      .tag h2 em {
+        font-style: normal;
+        color: var(--a-accent);
+      }
+      .swatches {
+        display: flex;
+        gap: 10px;
+      }
+      .sw {
+        width: 44px;
+        height: 44px;
+        border-radius: 7px;
+        border: 1px solid var(--a-hairline);
+      }
 
-  footer { display: flex; justify-content: space-between; padding-top: 26px;
-    font-family: var(--a-mono); font-size: 11px; letter-spacing: .18em;
-    color: var(--a-muted); text-transform: uppercase; }
-</style>
-</head>
-<body>
-  <header>
-    <span>iamnick — brand concept <span class="acc">A</span> / whoami</span>
-    <span>identity board · 01</span>
-  </header>
+      footer {
+        display: flex;
+        justify-content: space-between;
+        padding-top: 26px;
+        font-family: var(--a-mono);
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        color: var(--a-muted);
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <span>iamnick — brand concept <span class="acc">A</span> / whoami</span>
+      <span>identity board · 01</span>
+    </header>
 
-  <div class="grid">
-    <div class="panel cover">
-      <span class="label">Mark + Wordmark</span>
-      <!-- n with prompt-chevron counter -->
-      <svg width="150" height="150" viewBox="0 0 96 96" fill="none">
-        <rect x="2" y="2" width="92" height="92" rx="20" fill="#16181b" stroke="#26292d"/>
-        <path d="M28 70 V38 q0 -12 12 -12 h4 q12 0 12 12 v32" stroke="#f2f0eb" stroke-width="8" stroke-linecap="round" fill="none"/>
-        <path d="M43 47 l9 9 -9 9" stroke="#58c4dc" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-      </svg>
-      <div class="word"><span class="dim">~/</span>iamnick<span class="dot">.</span>dev</div>
-    </div>
-
-    <div class="panel browser">
-      <span class="label num">blog surface</span>
-      <div class="chrome">
-        <span class="dots"><span></span><span></span><span></span></span>
-        <div class="url">https://<b>iamnick.dev</b>/blog/teaching-agents-to-run-a-carnival</div>
+    <div class="grid">
+      <div class="panel cover">
+        <span class="label">Mark + Wordmark</span>
+        <!-- n with prompt-chevron counter -->
+        <svg width="150" height="150" viewBox="0 0 96 96" fill="none">
+          <rect x="2" y="2" width="92" height="92" rx="20" fill="#16181b" stroke="#26292d" />
+          <path
+            d="M28 70 V38 q0 -12 12 -12 h4 q12 0 12 12 v32"
+            stroke="#f2f0eb"
+            stroke-width="8"
+            stroke-linecap="round"
+            fill="none"
+          />
+          <path
+            d="M43 47 l9 9 -9 9"
+            stroke="#58c4dc"
+            stroke-width="6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+          />
+        </svg>
+        <div class="word"><span class="dim">~/</span>iamnick<span class="dot">.</span>dev</div>
       </div>
-      <div class="post">
-        <div class="meta">2026-07-17 <span>·</span> 7 min <span>·</span> agentic-workflows</div>
-        <h1>Teaching agents to run a carnival</h1>
-        <p>The fortune teller needed a fact source, the moderation queue needed a
-        human gate, and I needed a way to stop rebuilding context every session.
-        This is the working, shown.</p>
+
+      <div class="panel browser">
+        <span class="label num">blog surface</span>
+        <div class="chrome">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <div class="url">https://<b>iamnick.dev</b>/blog/teaching-agents-to-run-a-carnival</div>
+        </div>
+        <div class="post">
+          <div class="meta">2026-07-17 <span>·</span> 7 min <span>·</span> agentic-workflows</div>
+          <h1>Teaching agents to run a carnival</h1>
+          <p>
+            The fortune teller needed a fact source, the moderation queue needed a human gate, and I
+            needed a way to stop rebuilding context every session. This is the working, shown.
+          </p>
+        </div>
+      </div>
+
+      <div class="panel term">
+        <span class="label">Functional</span>
+        <div><span class="ps">$</span> whoami</div>
+        <div class="out">nick — senior front-end engineer</div>
+        <div><span class="ps">$</span> cat status</div>
+        <div class="out">building in the open<span class="cursor"></span></div>
+      </div>
+
+      <div class="panel construct">
+        <span class="label">Construction</span>
+        <svg width="230" height="230" viewBox="0 0 96 96" fill="none">
+          <circle cx="48" cy="38" r="22" stroke="#26292d" stroke-width="1" />
+          <line x1="28" y1="8" x2="28" y2="88" stroke="#26292d" stroke-width="1" />
+          <line x1="56" y1="8" x2="56" y2="88" stroke="#26292d" stroke-width="1" />
+          <line x1="8" y1="70" x2="88" y2="70" stroke="#26292d" stroke-width="1" />
+          <path
+            d="M28 70 V38 q0 -12 12 -12 h4 q12 0 12 12 v32"
+            stroke="#f2f0eb"
+            stroke-width="7"
+            stroke-linecap="round"
+            fill="none"
+          />
+          <path
+            d="M43 47 l9 9 -9 9"
+            stroke="#58c4dc"
+            stroke-width="5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            fill="none"
+          />
+          <circle cx="28" cy="70" r="2.5" fill="#58c4dc" />
+          <circle cx="56" cy="70" r="2.5" fill="#58c4dc" />
+        </svg>
+      </div>
+
+      <div class="panel tag">
+        <span class="label num">essence</span>
+        <h2>Showing the<br /><em>working</em>.</h2>
+        <div class="swatches">
+          <div class="sw" style="background: #0e0f11"></div>
+          <div class="sw" style="background: #16181b"></div>
+          <div class="sw" style="background: #f2f0eb"></div>
+          <div class="sw" style="background: #58c4dc"></div>
+        </div>
       </div>
     </div>
 
-    <div class="panel term">
-      <span class="label">Functional</span>
-      <div><span class="ps">$</span> whoami</div>
-      <div class="out">nick — senior front-end engineer</div>
-      <div><span class="ps">$</span> cat status</div>
-      <div class="out">building in the open<span class="cursor"></span></div>
-    </div>
-
-    <div class="panel construct">
-      <span class="label">Construction</span>
-      <svg width="230" height="230" viewBox="0 0 96 96" fill="none">
-        <circle cx="48" cy="38" r="22" stroke="#26292d" stroke-width="1"/>
-        <line x1="28" y1="8" x2="28" y2="88" stroke="#26292d" stroke-width="1"/>
-        <line x1="56" y1="8" x2="56" y2="88" stroke="#26292d" stroke-width="1"/>
-        <line x1="8" y1="70" x2="88" y2="70" stroke="#26292d" stroke-width="1"/>
-        <path d="M28 70 V38 q0 -12 12 -12 h4 q12 0 12 12 v32" stroke="#f2f0eb" stroke-width="7" stroke-linecap="round" fill="none"/>
-        <path d="M43 47 l9 9 -9 9" stroke="#58c4dc" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-        <circle cx="28" cy="70" r="2.5" fill="#58c4dc"/>
-        <circle cx="56" cy="70" r="2.5" fill="#58c4dc"/>
-      </svg>
-    </div>
-
-    <div class="panel tag">
-      <span class="label num">essence</span>
-      <h2>Showing the<br /><em>working</em>.</h2>
-      <div class="swatches">
-        <div class="sw" style="background:#0e0f11"></div>
-        <div class="sw" style="background:#16181b"></div>
-        <div class="sw" style="background:#f2f0eb"></div>
-        <div class="sw" style="background:#58c4dc"></div>
-      </div>
-    </div>
-  </div>
-
-  <footer>
-    <span>ink #0e0f11 · paper #f2f0eb · signal #58c4dc</span>
-    <span>space grotesk / inter / jetbrains mono · utopia fluid scale</span>
-  </footer>
-</body>
+    <footer>
+      <span>ink #0e0f11 · paper #f2f0eb · signal #58c4dc</span>
+      <span>space grotesk / inter / jetbrains mono · utopia fluid scale</span>
+    </footer>
+  </body>
 </html>

--- a/docs/brand/boards/concept-b-notebook.html
+++ b/docs/brand/boards/concept-b-notebook.html
@@ -1,164 +1,341 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<title>iamnick — Concept B — The Notebook</title>
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet" />
-<style>
-  /* ---- Concept B token source ---- */
-  :root {
-    --b-paper: #faf7f0;      /* base — warm ivory */
-    --b-panel: #ffffff;
-    --b-ink: #1c1b18;        /* near-black warm ink */
-    --b-muted: #8a857b;
-    --b-accent: #2545c8;     /* ultramarine */
-    --b-ochre: #d9a441;      /* secondary highlight */
-    --b-hairline: #e6e0d4;
-    --b-display: 'Fraunces', serif;
-    --b-text: 'Inter', sans-serif;
-    --b-mono: 'JetBrains Mono', monospace;
-  }
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body {
-    width: 1600px; height: 1200px;
-    background: var(--b-paper);
-    font-family: var(--b-text); color: var(--b-ink);
-    padding: 48px 56px 40px; display: flex; flex-direction: column;
-  }
-  header {
-    display: flex; justify-content: space-between; align-items: baseline;
-    font-family: var(--b-mono); font-size: 12px; letter-spacing: .14em;
-    color: var(--b-muted); text-transform: uppercase; padding-bottom: 28px;
-  }
-  header .acc { color: var(--b-accent); }
-  .grid { flex: 1; display: grid; grid-template-columns: 1.35fr 1fr 1fr;
-    grid-template-rows: 1.25fr 1fr; gap: 22px; }
-  .panel { background: var(--b-panel); border: 1px solid var(--b-hairline);
-    border-radius: 10px; padding: 36px; position: relative; overflow: hidden;
-    box-shadow: 0 1px 2px rgba(28,27,24,.04); }
-  .label { position: absolute; top: 18px; left: 22px; font-family: var(--b-mono);
-    font-size: 10px; letter-spacing: .2em; color: var(--b-muted); text-transform: uppercase; }
-  .num { left: auto; right: 22px; }
+  <head>
+    <meta charset="utf-8" />
+    <title>iamnick — Concept B — The Notebook</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500&family=JetBrains+Mono:wght@400&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ---- Concept B token source ---- */
+      :root {
+        --b-paper: #faf7f0; /* base — warm ivory */
+        --b-panel: #ffffff;
+        --b-ink: #1c1b18; /* near-black warm ink */
+        --b-muted: #8a857b;
+        --b-accent: #2545c8; /* ultramarine */
+        --b-ochre: #d9a441; /* secondary highlight */
+        --b-hairline: #e6e0d4;
+        --b-display: 'Fraunces', serif;
+        --b-text: 'Inter', sans-serif;
+        --b-mono: 'JetBrains Mono', monospace;
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        width: 1600px;
+        height: 1200px;
+        background: var(--b-paper);
+        font-family: var(--b-text);
+        color: var(--b-ink);
+        padding: 48px 56px 40px;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        font-family: var(--b-mono);
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        color: var(--b-muted);
+        text-transform: uppercase;
+        padding-bottom: 28px;
+      }
+      header .acc {
+        color: var(--b-accent);
+      }
+      .grid {
+        flex: 1;
+        display: grid;
+        grid-template-columns: 1.35fr 1fr 1fr;
+        grid-template-rows: 1.25fr 1fr;
+        gap: 22px;
+      }
+      .panel {
+        background: var(--b-panel);
+        border: 1px solid var(--b-hairline);
+        border-radius: 10px;
+        padding: 36px;
+        position: relative;
+        overflow: hidden;
+        box-shadow: 0 1px 2px rgba(28, 27, 24, 0.04);
+      }
+      .label {
+        position: absolute;
+        top: 18px;
+        left: 22px;
+        font-family: var(--b-mono);
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        color: var(--b-muted);
+        text-transform: uppercase;
+      }
+      .num {
+        left: auto;
+        right: 22px;
+      }
 
-  /* 1 — logo cover */
-  .cover { display: flex; flex-direction: column; justify-content: center; align-items: center; gap: 30px; }
-  .mono-mark { font-family: var(--b-display); font-size: 120px; font-weight: 500;
-    letter-spacing: -0.03em; line-height: 1; }
-  .mono-mark .stop { color: var(--b-accent); }
-  .cover .word { font-family: var(--b-text); font-size: 21px; letter-spacing: .34em;
-    text-transform: uppercase; color: var(--b-ink); }
-  .cover .word b { color: var(--b-accent); font-weight: 500; }
+      /* 1 — logo cover */
+      .cover {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 30px;
+      }
+      .mono-mark {
+        font-family: var(--b-display);
+        font-size: 120px;
+        font-weight: 500;
+        letter-spacing: -0.03em;
+        line-height: 1;
+      }
+      .mono-mark .stop {
+        color: var(--b-accent);
+      }
+      .cover .word {
+        font-family: var(--b-text);
+        font-size: 21px;
+        letter-spacing: 0.34em;
+        text-transform: uppercase;
+        color: var(--b-ink);
+      }
+      .cover .word b {
+        color: var(--b-accent);
+        font-weight: 500;
+      }
 
-  /* 2 — product surface */
-  .browser { grid-column: 2 / 4; display: flex; flex-direction: column; padding: 0; }
-  .chrome { display: flex; align-items: center; gap: 14px; padding: 16px 22px;
-    border-bottom: 1px solid var(--b-hairline); }
-  .dots span { display: inline-block; width: 9px; height: 9px; border-radius: 50%;
-    background: #e0dacc; margin-right: 5px; }
-  .url { flex: 1; background: var(--b-paper); border: 1px solid var(--b-hairline); border-radius: 6px;
-    font-family: var(--b-mono); font-size: 12.5px; color: var(--b-muted); padding: 8px 14px; }
-  .url b { color: var(--b-ink); font-weight: 500; }
-  .post { padding: 42px 52px; }
-  .post .kicker { font-family: var(--b-mono); font-size: 12px; letter-spacing: .22em;
-    text-transform: uppercase; color: var(--b-accent); margin-bottom: 16px; }
-  .post h1 { font-family: var(--b-display); font-size: 42px; font-weight: 600;
-    line-height: 1.12; margin-bottom: 16px; letter-spacing: -0.01em; }
-  .post p { font-size: 16.5px; line-height: 1.7; color: #4a463e; max-width: 58ch; }
-  .post p mark { background: linear-gradient(transparent 62%, rgba(217,164,65,.45) 62%);
-    color: inherit; }
+      /* 2 — product surface */
+      .browser {
+        grid-column: 2 / 4;
+        display: flex;
+        flex-direction: column;
+        padding: 0;
+      }
+      .chrome {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 16px 22px;
+        border-bottom: 1px solid var(--b-hairline);
+      }
+      .dots span {
+        display: inline-block;
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: #e0dacc;
+        margin-right: 5px;
+      }
+      .url {
+        flex: 1;
+        background: var(--b-paper);
+        border: 1px solid var(--b-hairline);
+        border-radius: 6px;
+        font-family: var(--b-mono);
+        font-size: 12.5px;
+        color: var(--b-muted);
+        padding: 8px 14px;
+      }
+      .url b {
+        color: var(--b-ink);
+        font-weight: 500;
+      }
+      .post {
+        padding: 42px 52px;
+      }
+      .post .kicker {
+        font-family: var(--b-mono);
+        font-size: 12px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--b-accent);
+        margin-bottom: 16px;
+      }
+      .post h1 {
+        font-family: var(--b-display);
+        font-size: 42px;
+        font-weight: 600;
+        line-height: 1.12;
+        margin-bottom: 16px;
+        letter-spacing: -0.01em;
+      }
+      .post p {
+        font-size: 16.5px;
+        line-height: 1.7;
+        color: #4a463e;
+        max-width: 58ch;
+      }
+      .post p mark {
+        background: linear-gradient(transparent 62%, rgba(217, 164, 65, 0.45) 62%);
+        color: inherit;
+      }
 
-  /* 3 — functional: frontmatter page */
-  .front { background: var(--b-panel); font-family: var(--b-mono); font-size: 15.5px;
-    line-height: 2.1; display: flex; flex-direction: column; justify-content: center;
-    padding-left: 46px;
-    background-image: repeating-linear-gradient(transparent 0 32px, #f0ebdf 32px 33px); }
-  .front .key { color: var(--b-muted); }
-  .front .val { color: var(--b-ink); }
-  .front .rule { color: var(--b-accent); }
+      /* 3 — functional: frontmatter page */
+      .front {
+        background: var(--b-panel);
+        font-family: var(--b-mono);
+        font-size: 15.5px;
+        line-height: 2.1;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding-left: 46px;
+        background-image: repeating-linear-gradient(transparent 0 32px, #f0ebdf 32px 33px);
+      }
+      .front .key {
+        color: var(--b-muted);
+      }
+      .front .val {
+        color: var(--b-ink);
+      }
+      .front .rule {
+        color: var(--b-accent);
+      }
 
-  /* 4 — construction */
-  .construct { display: flex; align-items: center; justify-content: center; }
+      /* 4 — construction */
+      .construct {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  /* 5 — tagline */
-  .tag { display: flex; flex-direction: column; justify-content: center; padding: 44px; gap: 22px;
-    background: var(--b-ink); color: var(--b-paper); border-color: var(--b-ink); }
-  .tag h2 { font-family: var(--b-display); font-size: 34px; font-weight: 500; line-height: 1.28; }
-  .tag h2 em { font-style: italic; color: var(--b-ochre); }
-  .swatches { display: flex; gap: 10px; }
-  .sw { width: 44px; height: 44px; border-radius: 7px; border: 1px solid rgba(250,247,240,.2); }
+      /* 5 — tagline */
+      .tag {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding: 44px;
+        gap: 22px;
+        background: var(--b-ink);
+        color: var(--b-paper);
+        border-color: var(--b-ink);
+      }
+      .tag h2 {
+        font-family: var(--b-display);
+        font-size: 34px;
+        font-weight: 500;
+        line-height: 1.28;
+      }
+      .tag h2 em {
+        font-style: italic;
+        color: var(--b-ochre);
+      }
+      .swatches {
+        display: flex;
+        gap: 10px;
+      }
+      .sw {
+        width: 44px;
+        height: 44px;
+        border-radius: 7px;
+        border: 1px solid rgba(250, 247, 240, 0.2);
+      }
 
-  footer { display: flex; justify-content: space-between; padding-top: 26px;
-    font-family: var(--b-mono); font-size: 11px; letter-spacing: .18em;
-    color: var(--b-muted); text-transform: uppercase; }
-</style>
-</head>
-<body>
-  <header>
-    <span>iamnick — brand concept <span class="acc">B</span> / the notebook</span>
-    <span>identity board · 02</span>
-  </header>
+      footer {
+        display: flex;
+        justify-content: space-between;
+        padding-top: 26px;
+        font-family: var(--b-mono);
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        color: var(--b-muted);
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <span>iamnick — brand concept <span class="acc">B</span> / the notebook</span>
+      <span>identity board · 02</span>
+    </header>
 
-  <div class="grid">
-    <div class="panel cover">
-      <span class="label">Mark + Wordmark</span>
-      <div class="mono-mark">in<span class="stop">.</span></div>
-      <div class="word">iamnick<b>.dev</b></div>
-    </div>
-
-    <div class="panel browser">
-      <span class="label num">blog surface</span>
-      <div class="chrome">
-        <span class="dots"><span></span><span></span><span></span></span>
-        <div class="url">https://<b>iamnick.dev</b>/blog/teaching-agents-to-run-a-carnival</div>
+    <div class="grid">
+      <div class="panel cover">
+        <span class="label">Mark + Wordmark</span>
+        <div class="mono-mark">in<span class="stop">.</span></div>
+        <div class="word">iamnick<b>.dev</b></div>
       </div>
-      <div class="post">
-        <div class="kicker">Build journal — entry 01</div>
-        <h1>Teaching agents to run a carnival</h1>
-        <p>The fortune teller needed a fact source, the moderation queue needed a
-        human gate, and I needed to stop rebuilding context every session.
-        <mark>These are the notes from the build</mark> — decisions, dead ends and all.</p>
+
+      <div class="panel browser">
+        <span class="label num">blog surface</span>
+        <div class="chrome">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <div class="url">https://<b>iamnick.dev</b>/blog/teaching-agents-to-run-a-carnival</div>
+        </div>
+        <div class="post">
+          <div class="kicker">Build journal — entry 01</div>
+          <h1>Teaching agents to run a carnival</h1>
+          <p>
+            The fortune teller needed a fact source, the moderation queue needed a human gate, and I
+            needed to stop rebuilding context every session.
+            <mark>These are the notes from the build</mark> — decisions, dead ends and all.
+          </p>
+        </div>
+      </div>
+
+      <div class="panel front">
+        <span class="label">Functional</span>
+        <div><span class="rule">---</span></div>
+        <div><span class="key">title:</span> <span class="val">Notes from the build</span></div>
+        <div><span class="key">date:</span> <span class="val">2026-07-17</span></div>
+        <div><span class="key">tags:</span> <span class="val">[agentic, front-end]</span></div>
+        <div><span class="key">draft:</span> <span class="val">false</span></div>
+        <div><span class="rule">---</span></div>
+      </div>
+
+      <div class="panel construct">
+        <span class="label">Construction</span>
+        <svg width="240" height="220" viewBox="0 0 120 110" fill="none">
+          <line x1="10" y1="88" x2="110" y2="88" stroke="#e6e0d4" stroke-width="1" />
+          <line x1="10" y1="30" x2="110" y2="30" stroke="#e6e0d4" stroke-width="1" />
+          <line x1="10" y1="14" x2="110" y2="14" stroke="#e6e0d4" stroke-width="1" />
+          <text
+            x="30"
+            y="88"
+            font-family="Fraunces, serif"
+            font-size="76"
+            font-weight="500"
+            fill="#1c1b18"
+          >
+            in
+          </text>
+          <circle cx="97" cy="82" r="6.5" fill="#2545c8" />
+          <circle cx="36.5" cy="22" r="5" fill="#1c1b18" />
+          <line
+            x1="97"
+            y1="10"
+            x2="97"
+            y2="100"
+            stroke="#d9a441"
+            stroke-width="1"
+            stroke-dasharray="3 3"
+          />
+        </svg>
+      </div>
+
+      <div class="panel tag">
+        <span class="label num" style="color: rgba(250, 247, 240, 0.5)">essence</span>
+        <h2>Notes from<br />the <em>build</em>.</h2>
+        <div class="swatches">
+          <div class="sw" style="background: #faf7f0"></div>
+          <div class="sw" style="background: #1c1b18"></div>
+          <div class="sw" style="background: #2545c8"></div>
+          <div class="sw" style="background: #d9a441"></div>
+        </div>
       </div>
     </div>
 
-    <div class="panel front">
-      <span class="label">Functional</span>
-      <div><span class="rule">---</span></div>
-      <div><span class="key">title:</span> <span class="val">Notes from the build</span></div>
-      <div><span class="key">date:</span> <span class="val">2026-07-17</span></div>
-      <div><span class="key">tags:</span> <span class="val">[agentic, front-end]</span></div>
-      <div><span class="key">draft:</span> <span class="val">false</span></div>
-      <div><span class="rule">---</span></div>
-    </div>
-
-    <div class="panel construct">
-      <span class="label">Construction</span>
-      <svg width="240" height="220" viewBox="0 0 120 110" fill="none">
-        <line x1="10" y1="88" x2="110" y2="88" stroke="#e6e0d4" stroke-width="1"/>
-        <line x1="10" y1="30" x2="110" y2="30" stroke="#e6e0d4" stroke-width="1"/>
-        <line x1="10" y1="14" x2="110" y2="14" stroke="#e6e0d4" stroke-width="1"/>
-        <text x="30" y="88" font-family="Fraunces, serif" font-size="76" font-weight="500" fill="#1c1b18">in</text>
-        <circle cx="97" cy="82" r="6.5" fill="#2545c8"/>
-        <circle cx="36.5" cy="22" r="5" fill="#1c1b18"/>
-        <line x1="97" y1="10" x2="97" y2="100" stroke="#d9a441" stroke-width="1" stroke-dasharray="3 3"/>
-      </svg>
-    </div>
-
-    <div class="panel tag">
-      <span class="label num" style="color:rgba(250,247,240,.5)">essence</span>
-      <h2>Notes from<br />the <em>build</em>.</h2>
-      <div class="swatches">
-        <div class="sw" style="background:#faf7f0"></div>
-        <div class="sw" style="background:#1c1b18"></div>
-        <div class="sw" style="background:#2545c8"></div>
-        <div class="sw" style="background:#d9a441"></div>
-      </div>
-    </div>
-  </div>
-
-  <footer>
-    <span>ivory #faf7f0 · ink #1c1b18 · ultramarine #2545c8 · ochre #d9a441</span>
-    <span>fraunces / inter / jetbrains mono · utopia fluid scale</span>
-  </footer>
-</body>
+    <footer>
+      <span>ivory #faf7f0 · ink #1c1b18 · ultramarine #2545c8 · ochre #d9a441</span>
+      <span>fraunces / inter / jetbrains mono · utopia fluid scale</span>
+    </footer>
+  </body>
 </html>

--- a/docs/brand/boards/concept-c-blueprint.html
+++ b/docs/brand/boards/concept-c-blueprint.html
@@ -1,171 +1,347 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<title>iamnick — Concept C — Blueprint</title>
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-<style>
-  /* ---- Concept C token source ---- */
-  :root {
-    --c-slate: #14171c;      /* base */
-    --c-panel: #1a1e24;
-    --c-fog: #9aa3ad;        /* secondary text */
-    --c-white: #edf0f3;      /* primary text */
-    --c-accent: #7fa8d9;     /* steel blue */
-    --c-hairline: #262c34;
-    --c-grid: rgba(127,168,217,.07);
-    --c-sans: 'IBM Plex Sans', sans-serif;
-    --c-mono: 'IBM Plex Mono', monospace;
-  }
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body {
-    width: 1600px; height: 1200px; background: #101318;
-    font-family: var(--c-sans); color: var(--c-white);
-    padding: 48px 56px 40px; display: flex; flex-direction: column;
-  }
-  header { display: flex; justify-content: space-between; align-items: baseline;
-    font-family: var(--c-mono); font-size: 12px; letter-spacing: .14em;
-    color: var(--c-fog); text-transform: uppercase; padding-bottom: 28px; }
-  header .acc { color: var(--c-accent); }
-  .grid { flex: 1; display: grid; grid-template-columns: 1.35fr 1fr 1fr;
-    grid-template-rows: 1.25fr 1fr; gap: 22px; }
-  .panel { background: var(--c-panel); border: 1px solid var(--c-hairline);
-    border-radius: 10px; padding: 36px; position: relative; overflow: hidden; }
-  .blueprint-bg {
-    background-image:
-      linear-gradient(var(--c-grid) 1px, transparent 1px),
-      linear-gradient(90deg, var(--c-grid) 1px, transparent 1px);
-    background-size: 28px 28px;
-  }
-  .label { position: absolute; top: 18px; left: 22px; font-family: var(--c-mono);
-    font-size: 10px; letter-spacing: .2em; color: var(--c-fog); text-transform: uppercase; }
-  .num { left: auto; right: 22px; }
+  <head>
+    <meta charset="utf-8" />
+    <title>iamnick — Concept C — Blueprint</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ---- Concept C token source ---- */
+      :root {
+        --c-slate: #14171c; /* base */
+        --c-panel: #1a1e24;
+        --c-fog: #9aa3ad; /* secondary text */
+        --c-white: #edf0f3; /* primary text */
+        --c-accent: #7fa8d9; /* steel blue */
+        --c-hairline: #262c34;
+        --c-grid: rgba(127, 168, 217, 0.07);
+        --c-sans: 'IBM Plex Sans', sans-serif;
+        --c-mono: 'IBM Plex Mono', monospace;
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        width: 1600px;
+        height: 1200px;
+        background: #101318;
+        font-family: var(--c-sans);
+        color: var(--c-white);
+        padding: 48px 56px 40px;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        font-family: var(--c-mono);
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        color: var(--c-fog);
+        text-transform: uppercase;
+        padding-bottom: 28px;
+      }
+      header .acc {
+        color: var(--c-accent);
+      }
+      .grid {
+        flex: 1;
+        display: grid;
+        grid-template-columns: 1.35fr 1fr 1fr;
+        grid-template-rows: 1.25fr 1fr;
+        gap: 22px;
+      }
+      .panel {
+        background: var(--c-panel);
+        border: 1px solid var(--c-hairline);
+        border-radius: 10px;
+        padding: 36px;
+        position: relative;
+        overflow: hidden;
+      }
+      .blueprint-bg {
+        background-image:
+          linear-gradient(var(--c-grid) 1px, transparent 1px),
+          linear-gradient(90deg, var(--c-grid) 1px, transparent 1px);
+        background-size: 28px 28px;
+      }
+      .label {
+        position: absolute;
+        top: 18px;
+        left: 22px;
+        font-family: var(--c-mono);
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        color: var(--c-fog);
+        text-transform: uppercase;
+      }
+      .num {
+        left: auto;
+        right: 22px;
+      }
 
-  /* 1 — logo cover */
-  .cover { background: var(--c-slate); display: flex; flex-direction: column;
-    justify-content: center; align-items: center; gap: 32px; }
-  .cover .word { font-size: 50px; font-weight: 600; letter-spacing: -0.015em; }
-  .cover .word .thin { font-weight: 400; color: var(--c-fog); }
-  .cover .word .dot { color: var(--c-accent); }
+      /* 1 — logo cover */
+      .cover {
+        background: var(--c-slate);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 32px;
+      }
+      .cover .word {
+        font-size: 50px;
+        font-weight: 600;
+        letter-spacing: -0.015em;
+      }
+      .cover .word .thin {
+        font-weight: 400;
+        color: var(--c-fog);
+      }
+      .cover .word .dot {
+        color: var(--c-accent);
+      }
 
-  /* 2 — product surface */
-  .browser { grid-column: 2 / 4; display: flex; flex-direction: column; padding: 0; }
-  .chrome { display: flex; align-items: center; gap: 14px; padding: 16px 22px;
-    border-bottom: 1px solid var(--c-hairline); }
-  .dots span { display: inline-block; width: 9px; height: 9px; border-radius: 50%;
-    background: #2c333c; margin-right: 5px; }
-  .url { flex: 1; background: var(--c-slate); border: 1px solid var(--c-hairline);
-    border-radius: 6px; font-family: var(--c-mono); font-size: 12.5px;
-    color: var(--c-fog); padding: 8px 14px; }
-  .url b { color: var(--c-white); font-weight: 500; }
-  .post { padding: 44px 52px; }
-  .post .meta { font-family: var(--c-mono); font-size: 12.5px; color: var(--c-fog);
-    letter-spacing: .08em; margin-bottom: 18px; }
-  .post .meta b { color: var(--c-accent); font-weight: 500; }
-  .post h1 { font-size: 40px; font-weight: 600; letter-spacing: -0.02em;
-    line-height: 1.15; margin-bottom: 18px; }
-  .post p { font-size: 16.5px; line-height: 1.68; color: #b8bfc7; max-width: 58ch; }
-  .post p mark { background: linear-gradient(transparent 68%, rgba(127,168,217,.38) 68%);
-    color: #edf0f3; }
+      /* 2 — product surface */
+      .browser {
+        grid-column: 2 / 4;
+        display: flex;
+        flex-direction: column;
+        padding: 0;
+      }
+      .chrome {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 16px 22px;
+        border-bottom: 1px solid var(--c-hairline);
+      }
+      .dots span {
+        display: inline-block;
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: #2c333c;
+        margin-right: 5px;
+      }
+      .url {
+        flex: 1;
+        background: var(--c-slate);
+        border: 1px solid var(--c-hairline);
+        border-radius: 6px;
+        font-family: var(--c-mono);
+        font-size: 12.5px;
+        color: var(--c-fog);
+        padding: 8px 14px;
+      }
+      .url b {
+        color: var(--c-white);
+        font-weight: 500;
+      }
+      .post {
+        padding: 44px 52px;
+      }
+      .post .meta {
+        font-family: var(--c-mono);
+        font-size: 12.5px;
+        color: var(--c-fog);
+        letter-spacing: 0.08em;
+        margin-bottom: 18px;
+      }
+      .post .meta b {
+        color: var(--c-accent);
+        font-weight: 500;
+      }
+      .post h1 {
+        font-size: 40px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        line-height: 1.15;
+        margin-bottom: 18px;
+      }
+      .post p {
+        font-size: 16.5px;
+        line-height: 1.68;
+        color: #b8bfc7;
+        max-width: 58ch;
+      }
+      .post p mark {
+        background: linear-gradient(transparent 68%, rgba(127, 168, 217, 0.38) 68%);
+        color: #edf0f3;
+      }
 
-  /* 3 — functional: spec sheet */
-  .spec { background: var(--c-slate); font-family: var(--c-mono); font-size: 15px;
-    line-height: 2.15; display: flex; flex-direction: column; justify-content: center;
-    padding-left: 46px; }
-  .spec .k { color: var(--c-fog); display: inline-block; width: 12ch; }
-  .spec .v { color: var(--c-white); }
-  .spec .a { color: var(--c-accent); }
+      /* 3 — functional: spec sheet */
+      .spec {
+        background: var(--c-slate);
+        font-family: var(--c-mono);
+        font-size: 15px;
+        line-height: 2.15;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding-left: 46px;
+      }
+      .spec .k {
+        color: var(--c-fog);
+        display: inline-block;
+        width: 12ch;
+      }
+      .spec .v {
+        color: var(--c-white);
+      }
+      .spec .a {
+        color: var(--c-accent);
+      }
 
-  /* 4 — construction */
-  .construct { display: flex; align-items: center; justify-content: center; }
+      /* 4 — construction */
+      .construct {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-  /* 5 — tagline */
-  .tag { background: var(--c-slate); display: flex; flex-direction: column;
-    justify-content: center; padding: 44px; gap: 22px; }
-  .tag h2 { font-size: 34px; font-weight: 500; letter-spacing: -0.01em; line-height: 1.28; }
-  .tag h2 em { font-style: normal; color: var(--c-accent); }
-  .swatches { display: flex; gap: 10px; }
-  .sw { width: 44px; height: 44px; border-radius: 7px; border: 1px solid var(--c-hairline); }
+      /* 5 — tagline */
+      .tag {
+        background: var(--c-slate);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding: 44px;
+        gap: 22px;
+      }
+      .tag h2 {
+        font-size: 34px;
+        font-weight: 500;
+        letter-spacing: -0.01em;
+        line-height: 1.28;
+      }
+      .tag h2 em {
+        font-style: normal;
+        color: var(--c-accent);
+      }
+      .swatches {
+        display: flex;
+        gap: 10px;
+      }
+      .sw {
+        width: 44px;
+        height: 44px;
+        border-radius: 7px;
+        border: 1px solid var(--c-hairline);
+      }
 
-  footer { display: flex; justify-content: space-between; padding-top: 26px;
-    font-family: var(--c-mono); font-size: 11px; letter-spacing: .18em;
-    color: var(--c-fog); text-transform: uppercase; }
-</style>
-</head>
-<body>
-  <header>
-    <span>iamnick — brand concept <span class="acc">C</span> / blueprint</span>
-    <span>identity board · 03</span>
-  </header>
+      footer {
+        display: flex;
+        justify-content: space-between;
+        padding-top: 26px;
+        font-family: var(--c-mono);
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        color: var(--c-fog);
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <span>iamnick — brand concept <span class="acc">C</span> / blueprint</span>
+      <span>identity board · 03</span>
+    </header>
 
-  <div class="grid">
-    <div class="panel cover blueprint-bg">
-      <span class="label">Mark + Wordmark</span>
-      <svg width="150" height="150" viewBox="0 0 96 96" fill="none">
-        <rect x="2" y="2" width="92" height="92" rx="12" fill="#1a1e24" stroke="#262c34"/>
-        <path d="M30 72 V40" stroke="#edf0f3" stroke-width="7" stroke-linecap="round"/>
-        <path d="M30 46 q0 -20 18 -20 q18 0 18 20 v26" stroke="#edf0f3" stroke-width="7" stroke-linecap="round" fill="none"/>
-        <path d="M66 26 v46" stroke="#7fa8d9" stroke-width="2" stroke-dasharray="4 4"/>
-      </svg>
-      <div class="word"><span class="thin">iam</span>nick<span class="dot">.</span>dev</div>
-    </div>
-
-    <div class="panel browser">
-      <span class="label num">blog surface</span>
-      <div class="chrome">
-        <span class="dots"><span></span><span></span><span></span></span>
-        <div class="url">https://<b>iamnick.dev</b>/blog/teaching-agents-to-run-a-carnival</div>
+    <div class="grid">
+      <div class="panel cover blueprint-bg">
+        <span class="label">Mark + Wordmark</span>
+        <svg width="150" height="150" viewBox="0 0 96 96" fill="none">
+          <rect x="2" y="2" width="92" height="92" rx="12" fill="#1a1e24" stroke="#262c34" />
+          <path d="M30 72 V40" stroke="#edf0f3" stroke-width="7" stroke-linecap="round" />
+          <path
+            d="M30 46 q0 -20 18 -20 q18 0 18 20 v26"
+            stroke="#edf0f3"
+            stroke-width="7"
+            stroke-linecap="round"
+            fill="none"
+          />
+          <path d="M66 26 v46" stroke="#7fa8d9" stroke-width="2" stroke-dasharray="4 4" />
+        </svg>
+        <div class="word"><span class="thin">iam</span>nick<span class="dot">.</span>dev</div>
       </div>
-      <div class="post">
-        <div class="meta"><b>fig. 07</b> — 2026-07-17 · 7 min · agentic-workflows</div>
-        <h1>Teaching agents to run a carnival</h1>
-        <p>The fortune teller needed a fact source, the moderation queue needed a
-        human gate, and I needed to stop rebuilding context every session.
-        <mark>Drawn to scale, decisions dimensioned.</mark></p>
+
+      <div class="panel browser">
+        <span class="label num">blog surface</span>
+        <div class="chrome">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <div class="url">https://<b>iamnick.dev</b>/blog/teaching-agents-to-run-a-carnival</div>
+        </div>
+        <div class="post">
+          <div class="meta"><b>fig. 07</b> — 2026-07-17 · 7 min · agentic-workflows</div>
+          <h1>Teaching agents to run a carnival</h1>
+          <p>
+            The fortune teller needed a fact source, the moderation queue needed a human gate, and I
+            needed to stop rebuilding context every session.
+            <mark>Drawn to scale, decisions dimensioned.</mark>
+          </p>
+        </div>
+      </div>
+
+      <div class="panel spec">
+        <span class="label">Functional</span>
+        <div>
+          <span class="k">type</span>
+          <span class="v">fluid <span class="a">18 → 21px</span> / utopia</span>
+        </div>
+        <div>
+          <span class="k">measure</span> <span class="v"><span class="a">68ch</span> max</span>
+        </div>
+        <div><span class="k">space</span> <span class="v">s-2 … s+4, paired</span></div>
+        <div><span class="k">contrast</span> <span class="v">AAA body text</span></div>
+      </div>
+
+      <div class="panel construct blueprint-bg">
+        <span class="label">Construction</span>
+        <svg width="240" height="230" viewBox="0 0 100 96" fill="none">
+          <circle cx="50" cy="42" r="26" stroke="#2c3946" stroke-width="1" />
+          <circle cx="50" cy="42" r="17" stroke="#2c3946" stroke-width="1" />
+          <line x1="30" y1="6" x2="30" y2="90" stroke="#2c3946" stroke-width="1" />
+          <line x1="70" y1="6" x2="70" y2="90" stroke="#2c3946" stroke-width="1" />
+          <line x1="6" y1="74" x2="94" y2="74" stroke="#2c3946" stroke-width="1" />
+          <path d="M30 74 V44" stroke="#edf0f3" stroke-width="6" stroke-linecap="round" />
+          <path
+            d="M30 48 q0 -18 20 -18 q20 0 20 18 v26"
+            stroke="#edf0f3"
+            stroke-width="6"
+            stroke-linecap="round"
+            fill="none"
+          />
+          <circle cx="30" cy="74" r="2.5" fill="#7fa8d9" />
+          <circle cx="70" cy="74" r="2.5" fill="#7fa8d9" />
+          <circle cx="50" cy="30" r="2.5" fill="#7fa8d9" />
+          <text x="76" y="60" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7fa8d9">
+            r=26
+          </text>
+        </svg>
+      </div>
+
+      <div class="panel tag">
+        <span class="label num">essence</span>
+        <h2>Measured<br /><em>twice</em>.</h2>
+        <div class="swatches">
+          <div class="sw" style="background: #14171c"></div>
+          <div class="sw" style="background: #1a1e24"></div>
+          <div class="sw" style="background: #edf0f3"></div>
+          <div class="sw" style="background: #7fa8d9"></div>
+        </div>
       </div>
     </div>
 
-    <div class="panel spec">
-      <span class="label">Functional</span>
-      <div><span class="k">type</span> <span class="v">fluid <span class="a">18 → 21px</span> / utopia</span></div>
-      <div><span class="k">measure</span> <span class="v"><span class="a">68ch</span> max</span></div>
-      <div><span class="k">space</span> <span class="v">s-2 … s+4, paired</span></div>
-      <div><span class="k">contrast</span> <span class="v">AAA body text</span></div>
-    </div>
-
-    <div class="panel construct blueprint-bg">
-      <span class="label">Construction</span>
-      <svg width="240" height="230" viewBox="0 0 100 96" fill="none">
-        <circle cx="50" cy="42" r="26" stroke="#2c3946" stroke-width="1"/>
-        <circle cx="50" cy="42" r="17" stroke="#2c3946" stroke-width="1"/>
-        <line x1="30" y1="6" x2="30" y2="90" stroke="#2c3946" stroke-width="1"/>
-        <line x1="70" y1="6" x2="70" y2="90" stroke="#2c3946" stroke-width="1"/>
-        <line x1="6" y1="74" x2="94" y2="74" stroke="#2c3946" stroke-width="1"/>
-        <path d="M30 74 V44" stroke="#edf0f3" stroke-width="6" stroke-linecap="round"/>
-        <path d="M30 48 q0 -18 20 -18 q20 0 20 18 v26" stroke="#edf0f3" stroke-width="6" stroke-linecap="round" fill="none"/>
-        <circle cx="30" cy="74" r="2.5" fill="#7fa8d9"/>
-        <circle cx="70" cy="74" r="2.5" fill="#7fa8d9"/>
-        <circle cx="50" cy="30" r="2.5" fill="#7fa8d9"/>
-        <text x="76" y="60" font-family="IBM Plex Mono, monospace" font-size="7" fill="#7fa8d9">r=26</text>
-      </svg>
-    </div>
-
-    <div class="panel tag">
-      <span class="label num">essence</span>
-      <h2>Measured<br /><em>twice</em>.</h2>
-      <div class="swatches">
-        <div class="sw" style="background:#14171c"></div>
-        <div class="sw" style="background:#1a1e24"></div>
-        <div class="sw" style="background:#edf0f3"></div>
-        <div class="sw" style="background:#7fa8d9"></div>
-      </div>
-    </div>
-  </div>
-
-  <footer>
-    <span>slate #14171c · fog #9aa3ad · steel #7fa8d9</span>
-    <span>ibm plex sans / ibm plex mono · utopia fluid scale</span>
-  </footer>
-</body>
+    <footer>
+      <span>slate #14171c · fog #9aa3ad · steel #7fa8d9</span>
+      <span>ibm plex sans / ibm plex mono · utopia fluid scale</span>
+    </footer>
+  </body>
 </html>

--- a/docs/redesign/blog-handoff.md
+++ b/docs/redesign/blog-handoff.md
@@ -1,14 +1,14 @@
 # Blog — Build Handoff
 
-> **Mission for the next session:** build **Stage 1 — content pipeline + typed layer**: wire in
-> Velite (ADR-0008), create `content/blog/` with two seed posts (one published, one Draft), the Zod
-> frontmatter schema, and a typed accessor module with a single `publishedPosts` accessor, mirroring
-> the `src/content/cv.ts` house pattern. Gate: `pnpm validate`.
+> **Mission for the next session:** build **Stage 2 — routes + reading template**: `/blog` and
+> `/blog/[slug]` on the Blueprint brand, brand-prefixed Utopia tokens in `@theme`, Shiki
+> highlighting, prev/next, reading time, SiteNav Blog link. All public reads go through
+> `publishedPosts` (`src/content/blog.ts`). Gates: `pnpm validate`, the `@ci` blog e2e spec, and
+> two human gates — Nick reads the feel, monogram small-size pass.
 >
 > Specs are done and live in `docs/blog/` — this doc points at them and adds only build-facing
-> operational detail. Read `CONTEXT.md` first (Blog/Post/Tag/Draft entries just landed). Spec branch:
-> `feature/blog-stage-0`; each stage gets its own branch, PR to master — the site is live, every
-> slice must leave production shippable.
+> operational detail. Read `CONTEXT.md` first (Blog/Post/Tag/Draft entries). Each stage gets its
+> own branch, PR to master — the site is live, every slice must leave production shippable.
 
 ---
 
@@ -17,10 +17,10 @@
 1. Read the spec set: `docs/blog/discovery.md` (decision log, rows 1–19), `docs/blog/prd.md` (what
    launch must include), `docs/blog/agentic-workflow.md` (how each stage runs and gates). ADRs
    0008–0011 are all **accepted** and binding.
-2. Stage order: **0 ✅ → B ✅ → 1 → 2 → 4 → 5** (Stage 3 deleted, ADR-0011; numbering preserved).
+2. Stage order: **0 ✅ → B ✅ → 1 ✅ → 2 → 4 → 5** (Stage 3 deleted, ADR-0011; numbering preserved).
 3. Every stage is bracketed by carnival-context **Brief** before and **Absorb** after; Absorb also
    appends a dated paragraph to `docs/blog/journal.md`.
-4. Stage 1 next (see §8). Do not duplicate spec content into code comments or this doc — the specs
+4. Stage 2 next (see §8). Do not duplicate spec content into code comments or this doc — the specs
    are the source.
 
 ---
@@ -37,10 +37,32 @@
   source.
 - **Glossary**: Blog, Post, Tag, Draft entries are in `CONTEXT.md` (plain English, no
   carnival-register naming — ADR-0011). Reviewed by glossary-guard.
-- **No code exists.** No content tooling in `package.json`, no `/blog` routes, no `content/blog/`
-  directory, no Blog link in `src/components/nav/SiteNav.tsx`. The pipeline starts from zero.
-- **House pattern to mirror**: `src/content/cv.ts` — typed data, Vitest tests beside it
-  (`cv.test.ts`), serialiser (`serializeCv.ts`).
+- **Content pipeline live** (Stage 1, 2026-07-17, `feature/blog-stage-1`): velite ^0.4.0
+  (devDependency) with `velite.config.ts` — posts collection from `content/blog/**/*.mdx`, Zod
+  frontmatter contract (title 3–99, description 10–160 so it stays usable as a meta description,
+  isodate `date`/`updated`, tags default `[]`, draft default `false`, `s.slug('blog')` uniqueness,
+  `s.metadata()` reading time, `s.excerpt()`, `s.mdx()` compiled output, permalink transform
+  `/blog/{slug}`). Invalid frontmatter fails `velite build`, therefore `pnpm validate` and the
+  production build.
+- **Typed accessor**: `src/content/blog.ts` — `allPosts` (dev/tests only) and `publishedPosts`
+  (**the** single public read: Draft-filtered, newest-first), with `src/content/blog.test.ts`
+  beside it (6 tests: published non-empty, Draft never leaks, ordering, slug/permalink
+  uniqueness + shape, frontmatter contract, derived reading time + compiled MDX).
+- **Seed Posts** in `content/blog/`: `building-this-blog-in-the-open.mdx` (published, carries a
+  code block as the Stage 2 highlighting test) and `designing-the-publish-pipeline.mdx` (Draft).
+  Every later stage tests against real content.
+- **Toolchain wired**: `#velite` path alias (tsconfig + vitest); `.velite/` ignored in
+  git/prettier/eslint/knip; knip entry `velite.config.ts`; scripts `content` (`velite build`) and
+  `build` (`velite build && next build`); `validate` prepends `pnpm content`; CI has a "Build
+  content layer (velite)" step; `next.config.ts` starts velite watch in dev only (`VELITE_STARTED`
+  guard) — production builds run velite explicitly, no race.
+- **ESLint three.js ban landed early** (planned Stage 1-or-2, done at Stage 1): `eslint.config.mjs`
+  scopes `no-restricted-imports` over `src/app/blog/**`, `src/components/blog/**`,
+  `src/content/blog.ts` with patterns `three`, `three/*`, `@react-three/*`.
+- **No routes yet.** No `/blog` pages, no Blog link in `src/components/nav/SiteNav.tsx`, no brand
+  tokens in `@theme` — all Stage 2.
+- **Master is red** on the PR #72 merge (prettier — see §7); the fix is on `feature/blog-stage-1`
+  and merging this branch restores green.
 
 ## 2. Integration map
 
@@ -77,8 +99,9 @@ suite (Stages 2/4/5).
   the carnival's fixed px tokens or its letterpress/ticket utilities; carnival components never
   reference `--brand-*` tokens. No carnival vocabulary in blog copy or identifiers.
 - **No three.js under blog code:** `three` / `@react-three/*` are banned imports for blog routes and
-  components. Enforce with an ESLint `no-restricted-imports` block cloning the `@/content/cv` ban at
-  `eslint.config.mjs` lines ~44–62 (Stage 1 or 2, whenever blog source directories first exist).
+  components. **Enforced** since Stage 1 — the `no-restricted-imports` block in `eslint.config.mjs`
+  already covers `src/app/blog/**` and `src/components/blog/**`; new blog directories are caught
+  automatically, do not re-add.
 - **Single accessor:** everything public (params, index, tags, sitemap, RSS) reads `publishedPosts`.
   Draft exclusion lives nowhere else.
 - **Build-time only:** MDX compilation and Shiki-class highlighting happen at build; no client-side
@@ -122,11 +145,14 @@ first-load JS budget → baseline recorded at Stage 2.
 - **Velite MDX render = compiled-function evaluation** (`new Function` at render, the standard
   compiled-MDX pattern). Harmless today; noted in ADR-0008 for any future CSP hardening — do not add
   a strict `script-src` without accounting for it.
-- **Velite generates an output directory** — teach knip and ESLint about it at Stage 1 or
-  `pnpm validate` fails on phantom unused/unresolved files.
-- **The ESLint boundary shape to clone** is the `@/content/cv` ban at `eslint.config.mjs` ~44–62
-  (files-scoped `no-restricted-imports` with a message pointing at the doc). Use `patterns` for
-  `@react-three/*`.
+- **pnpm 11 `allowBuilds` blocks esbuild** (velite's transitive dep). `pnpm-workspace.yaml` shipped
+  with a literal placeholder line under `allowBuilds` that broke `pnpm exec` entirely until it was
+  set to a real value; now `esbuild: true` with a comment. Any new dependency with a build script
+  needs its own entry there.
+- **`prettier --check .` covers `.html` but lint-staged only formats json/css/md** — the Stage B
+  brand-board HTMLs slipped through unformatted and broke master CI on the PR #72 merge. Boards and
+  `eslint.config.mjs` reformatted on `feature/blog-stage-1`; consider widening the lint-staged glob
+  later so the two can't disagree again.
 - **First-load JS baseline** for blog routes: record from `next build` output at Stage 2 in this
   doc; growth is a finding at every later gate, never silent.
 - **Brand monogram owes a refinement pass** — small-size distinctiveness (favicon/app-icon test) —
@@ -136,11 +162,9 @@ first-load JS budget → baseline recorded at Stage 2.
 
 ## 8. Build order
 
-1. **Stage 1 — content pipeline + typed layer** (next; gate `pnpm validate`): Velite wired;
-   `content/blog/` with two seed posts, one `draft: true`; Zod frontmatter schema per §5; derived
-   reading time + excerpts; typed accessor with `publishedPosts`, Vitest tests beside it; knip/ESLint
-   taught about generated output.
-2. **Stage 2 — routes + reading template**: `/blog`, `/blog/[slug]`; brand-prefixed Utopia tokens
+1. ~~**Stage 1 — content pipeline + typed layer**~~ ✅ done (2026-07-17, `feature/blog-stage-1`,
+   gate `pnpm validate` green, 162 tests) — see §1.
+2. **Stage 2 — routes + reading template** (next): `/blog`, `/blog/[slug]`; brand-prefixed Utopia tokens
    land in `@theme`; Shiki highlighting; prev/next; reading time; SiteNav Blog link; record JS
    baseline. Human gates: reading feel + monogram pass.
 3. **Stage 4 — SEO surfaces**: `generateMetadata`, per-post OG image, `BlogPosting` JSON-LD, sitemap
@@ -153,10 +177,12 @@ Every stage: carnival-context Brief before, Absorb after, journal paragraph appe
 
 ## 9. What just happened
 
-**Stage 0 + Stage B complete** (2026-07-16 / 2026-07-17, `feature/blog-stage-0`, uncommitted at
-time of writing). Discovery interviews locked scope; ADRs 0008–0010 were accepted, then Nick
-corrected course within the hour: the Dark Carnival is a self-contained entity, not the site brand
-(ADR-0011) — which superseded the letterpress reading identity and deleted the riskiest planned
-stage (the live-HUD Utopia migration). Brand discovery then ran as three rendered HTML/Playwright
-concept boards; Nick ruled **Blueprint**. Glossary entries landed; glossary-guard reviewed them
-(one carnival-side advisory parked, §7). Nothing built yet — Stage 1 is a clean start.
+**Stage 1 complete** (2026-07-17, `feature/blog-stage-1`, gate `pnpm validate` fully green — 162
+tests). The content pipeline and typed layer landed exactly as specified: velite + Zod contract,
+two seed Posts (one published with a code block for the Stage 2 highlighting test, one Draft),
+`publishedPosts` as the single public read with tests beside it, and the full toolchain sweep
+(§1). The three.js ESLint ban came in a stage early. The stage was mechanical — the specs absorbed
+all the thinking — and both surprises were toolchain seams, not design: the pnpm 11 `allowBuilds`
+gate and the prettier/lint-staged HTML disagreement that turned master red on the PR #72 merge;
+both fixed on this branch (§7). Before that, Stage 0 + Stage B (PR #72) locked the specs
+(ADRs 0008–0011) and ruled the **Blueprint** brand.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,14 @@ import eslintConfigPrettier from 'eslint-config-prettier';
 
 export default tseslint.config(
   {
-    ignores: ['.next/**', 'node_modules/**', 'public/**', 'coverage/**', 'next-env.d.ts'],
+    ignores: [
+      '.next/**',
+      '.velite/**',
+      'node_modules/**',
+      'public/**',
+      'coverage/**',
+      'next-env.d.ts',
+    ],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,
@@ -71,6 +78,25 @@ export default tseslint.config(
     ],
     rules: {
       'no-restricted-imports': 'off',
+    },
+  },
+  {
+    // The Blog is an iamnick-brand surface with no live canvas (ADR-0002,
+    // ADR-0011): three.js must never enter its bundles.
+    files: ['src/app/blog/**', 'src/components/blog/**', 'src/content/blog.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['three', 'three/*', '@react-three/*'],
+              message:
+                'Blog code must stay canvas-free — three.js is banned under blog routes and components (docs/redesign/blog-handoff.md §4).',
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["scripts/*.mjs"],
+  "entry": ["scripts/*.mjs", "velite.config.ts"],
+  "ignore": [".velite/**"],
   "ignoreExportsUsedInFile": true
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,15 @@ import { varlockNextConfigPlugin } from '@varlock/nextjs-integration/plugin';
 // Vercel reads the pnpm override; see docs/DEPLOY.md.)
 const withVarlock = varlockNextConfigPlugin();
 
+// Velite watches content/blog/ during dev so MDX edits regenerate the typed
+// layer live. Production builds run `velite build` explicitly first (see the
+// `build` script) — deterministic, no race with Next's compile.
+const isDev = process.argv.includes('dev');
+if (isDev && !process.env.VELITE_STARTED) {
+  process.env.VELITE_STARTED = '1';
+  import('velite').then((velite) => velite.build({ watch: true, clean: false }));
+}
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "content": "velite build",
+    "build": "velite build && next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . && prettier --check .",
@@ -26,7 +27,7 @@
     "test:ci": "vitest run",
     "test:e2e": "playwright test",
     "knip": "knip",
-    "validate": "pnpm typecheck && pnpm lint && pnpm test:ci && pnpm knip && pnpm build",
+    "validate": "pnpm content && pnpm typecheck && pnpm lint && pnpm test:ci && pnpm knip && pnpm build",
     "prepare": "husky",
     "env:check": "varlock load"
   },
@@ -91,6 +92,7 @@
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.63.0",
+    "velite": "^0.4.0",
     "vitest": "^4.1.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       typescript-eslint:
         specifier: ^8.63.0
         version: 8.63.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      velite:
+        specifier: ^0.4.0
+        version: 0.4.0
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
@@ -414,6 +417,162 @@ packages:
 
   '@emotion/memoize@0.9.0':
     resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -671,6 +830,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
   '@mediapipe/tasks-vision@0.10.17':
     resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
@@ -1651,17 +1813,35 @@ packages:
   '@types/css-mediaquery@0.1.4':
     resolution: {integrity: sha512-DZyHAz716ZUctpqkUU2COwUoZ4gI6mZK2Q1oIz/fvNS6XHVpKSJgDnE7vRxZUBn9vjJHDVelCVW0dkshKOLFsA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/ndarray@1.0.14':
     resolution: {integrity: sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==}
@@ -1690,6 +1870,12 @@ packages:
 
   '@types/three@0.185.0':
     resolution: {integrity: sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
@@ -1753,6 +1939,9 @@ packages:
     resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
   '@use-gesture/core@10.3.1':
     resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
 
@@ -1767,6 +1956,13 @@ packages:
     peerDependencies:
       next: '>=14'
       varlock: ^1.10.0
+
+  '@varlock/nextjs-integration@1.1.5':
+    resolution: {integrity: sha512-AvFl9GdR21fCQhqP3cX3JeHmbiYMrvJFd64EgdyjIoyNlu91saF0sqT93U/6inxIk0NPelOCrRC7BodfUjqrzA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      next: '>=14'
+      varlock: ^1.11.0
 
   '@vercel/analytics@2.0.1':
     resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
@@ -2043,6 +2239,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2104,6 +2303,9 @@ packages:
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2111,6 +2313,18 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -2134,12 +2348,18 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2213,6 +2433,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2234,6 +2457,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2323,6 +2549,17 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2405,6 +2642,24 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -2429,6 +2684,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2609,6 +2867,15 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -2668,12 +2935,21 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
   iota-array@1.0.0:
     resolution: {integrity: sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2710,6 +2986,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2730,6 +3009,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -2741,6 +3023,10 @@ packages:
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2993,6 +3279,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3030,9 +3319,40 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -3054,6 +3374,90 @@ packages:
 
   meshoptimizer@1.2.0:
     resolution: {integrity: sha512-davRZeIJbxJrE24cwQle7ZDsxjdk/OphNOV83oX+efQinyoHY9Jcyz3MHbaoG0qySZajldGztNZ1RN/T19PZsg==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
@@ -3277,6 +3681,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -3365,6 +3772,9 @@ packages:
   property-graph@4.1.0:
     resolution: {integrity: sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -3399,6 +3809,20 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -3410,6 +3834,18 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -3553,6 +3989,13 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -3611,6 +4054,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
@@ -3626,6 +4072,12 @@ packages:
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -3733,6 +4185,9 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   troika-three-text@0.52.4:
     resolution: {integrity: sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==}
     peerDependencies:
@@ -3745,6 +4200,9 @@ packages:
 
   troika-worker-utils@0.52.0:
     resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -3809,8 +4267,29 @@ packages:
     resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
     engines: {node: '>=20.18.1'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   uniq@1.0.1:
     resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -3834,6 +4313,17 @@ packages:
     resolution: {integrity: sha512-o4YahQPmNFGjnYDkBYNWffMQBoQqrlzkBS473k4rFsbYfHH3J627/+62gfPYMTqhsg9HF4qC8ogtOR1vJSZUPA==}
     engines: {bun: '>=1.3.3', node: '>=22.3.0'}
     hasBin: true
+
+  velite@0.4.0:
+    resolution: {integrity: sha512-F7eatRsbm9RQ2d43YYufiS729USvE4BAkw9yNB4iuFUSfrY9bFGe6/lrY6OpgiyOL8BT9hVd1JoRfyotjPOGpQ==}
+    engines: {node: ^18.20.0 || >=20.3.0}
+    hasBin: true
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -4067,6 +4557,9 @@ packages:
         optional: true
       use-sync-external-store:
         optional: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4354,6 +4847,84 @@ snapshots:
   '@emotion/memoize@0.9.0':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
@@ -4524,7 +5095,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.11.0
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -4559,6 +5130,36 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mdx-js/mdx@3.1.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdx': 2.0.14
+      acorn: 8.17.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.0
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.17.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
@@ -5362,13 +5963,33 @@ snapshots:
 
   '@types/css-mediaquery@0.1.4': {}
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/draco3d@1.4.10': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
   '@types/estree@1.0.9': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdx@2.0.14': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/ndarray@1.0.14': {}
 
@@ -5400,6 +6021,10 @@ snapshots:
       '@types/webxr': 0.5.24
       fflate: 0.8.3
       meshoptimizer: 1.1.1
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/webxr@0.5.24': {}
 
@@ -5494,6 +6119,8 @@ snapshots:
       '@typescript-eslint/types': 8.63.0
       eslint-visitor-keys: 5.0.1
 
+  '@ungap/structured-clone@1.3.3': {}
+
   '@use-gesture/core@10.3.1': {}
 
   '@use-gesture/react@10.3.1(react@19.2.7)':
@@ -5502,6 +6129,11 @@ snapshots:
       react: 19.2.7
 
   '@varlock/nextjs-integration@1.1.4(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(varlock@1.10.0)':
+    dependencies:
+      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0)
+      varlock: 1.10.0
+
+  '@varlock/nextjs-integration@1.1.5(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(varlock@1.10.0)':
     dependencies:
       next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0)
       varlock: 1.10.0
@@ -5804,6 +6436,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -5865,12 +6499,22 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -5889,11 +6533,15 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  collapse-white-space@2.1.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
 
@@ -5963,6 +6611,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -5984,6 +6636,10 @@ snapshots:
       webgl-constants: 1.1.1
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   doctrine@2.1.0:
     dependencies:
@@ -6130,6 +6786,49 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.17.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -6265,6 +6964,35 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -6280,6 +7008,8 @@ snapshots:
   eventsource-parser@3.1.0: {}
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -6446,6 +7176,51 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-estree@3.1.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -6496,6 +7271,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  inline-style-parser@0.2.7: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -6503,6 +7280,13 @@ snapshots:
       side-channel: 1.1.1
 
   iota-array@1.0.0: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -6546,6 +7330,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -6568,6 +7354,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -6576,6 +7364,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -6839,6 +7629,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -6875,7 +7667,108 @@ snapshots:
     dependencies:
       semver: 7.8.4
 
+  markdown-extensions@2.0.0: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
 
@@ -6890,6 +7783,212 @@ snapshots:
   meshoptimizer@1.1.1: {}
 
   meshoptimizer@1.2.0: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.54.0: {}
 
@@ -6968,7 +8067,7 @@ snapshots:
 
   next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0):
     dependencies:
-      '@next/env': '@varlock/nextjs-integration@1.1.4(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(varlock@1.10.0)'
+      '@next/env': '@varlock/nextjs-integration@1.1.5(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(varlock@1.10.0))(varlock@1.10.0)'
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.36
       caniuse-lite: 1.0.30001799
@@ -7122,6 +8221,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -7198,6 +8307,8 @@ snapshots:
 
   property-graph@4.1.0: {}
 
+  property-information@7.2.0: {}
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
@@ -7220,6 +8331,35 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
+
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
 
   redent@3.0.0:
     dependencies:
@@ -7245,6 +8385,38 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-recma@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      hast-util-to-estree: 3.1.3
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-from-string@2.0.2: {}
 
@@ -7477,6 +8649,10 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
+  space-separated-tokens@2.0.2: {}
+
   stackback@0.0.2: {}
 
   stacktrace-parser@0.1.11:
@@ -7561,6 +8737,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
@@ -7572,6 +8753,14 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.3: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
@@ -7662,6 +8851,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
   troika-three-text@0.52.4(three@0.185.1):
     dependencies:
       bidi-js: 1.0.3
@@ -7675,6 +8866,8 @@ snapshots:
       three: 0.185.1
 
   troika-worker-utils@0.52.0: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -7755,7 +8948,44 @@ snapshots:
 
   undici@7.27.2: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   uniq@1.0.1: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -7774,6 +9004,25 @@ snapshots:
   utility-types@3.11.0: {}
 
   varlock@1.10.0: {}
+
+  velite@0.4.0:
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      esbuild: 0.25.12
+      sharp: 0.34.5
+      terser: 5.49.0
+    transitivePeerDependencies:
+      - supports-color
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.16(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0):
     dependencies:
@@ -7984,3 +9233,5 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)
+
+  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@
 allowBuilds:
   sharp: true # next/image optimization
   '@sentry/cli': true # source-map upload during build (when Sentry is configured)
+  esbuild: true # velite (blog content pipeline) loads its config via esbuild
 
 # varlock runtime integration: replace Next's internal env loader with varlock's
 # so .env.schema drives loading + validation + @sensitive redaction + leak

--- a/src/content/blog.test.ts
+++ b/src/content/blog.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { allPosts, publishedPosts } from './blog';
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}T/;
+
+describe('content/blog', () => {
+  it('has at least one published Post', () => {
+    expect(publishedPosts.length).toBeGreaterThan(0);
+  });
+
+  it('never exposes a Draft through publishedPosts', () => {
+    expect(publishedPosts.every((post) => !post.draft)).toBe(true);
+    for (const post of allPosts.filter((p) => p.draft)) {
+      expect(publishedPosts.map((p) => p.slug)).not.toContain(post.slug);
+    }
+  });
+
+  it('orders published Posts newest-first', () => {
+    const dates = publishedPosts.map((post) => post.date);
+    expect([...dates].sort((a, b) => b.localeCompare(a))).toEqual(dates);
+  });
+
+  it('gives every Post a unique slug and a matching permalink', () => {
+    const slugs = allPosts.map((post) => post.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+    for (const post of allPosts) {
+      expect(post.slug).toMatch(/^[a-z0-9-]+$/);
+      expect(post.permalink).toBe(`/blog/${post.slug}`);
+    }
+  });
+
+  it('honours the frontmatter contract on every Post', () => {
+    for (const post of allPosts) {
+      expect(post.title.trim(), `${post.slug} title`).not.toBe('');
+      expect(post.description.length, `${post.slug} description`).toBeGreaterThanOrEqual(10);
+      expect(post.description.length, `${post.slug} description`).toBeLessThanOrEqual(160);
+      expect(post.date, `${post.slug} date`).toMatch(ISO_DATE);
+      expect(Array.isArray(post.tags), `${post.slug} tags`).toBe(true);
+    }
+  });
+
+  it('derives reading time and compiled MDX for every Post', () => {
+    for (const post of allPosts) {
+      expect(post.metadata.readingTime, `${post.slug} readingTime`).toBeGreaterThan(0);
+      expect(post.code.length, `${post.slug} compiled MDX`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/content/blog.ts
+++ b/src/content/blog.ts
@@ -1,0 +1,18 @@
+import { posts } from '#velite';
+
+export type Post = (typeof posts)[number];
+
+/**
+ * All Posts including Drafts — dev-only surfaces (Draft preview, Stage 5) and
+ * tests may read this; nothing public ever should.
+ */
+export const allPosts: readonly Post[] = posts;
+
+/**
+ * The only public read of the blog content layer (docs/redesign/blog-handoff.md §4):
+ * static params, the index, tag pages, sitemap and RSS all consume this list.
+ * Draft exclusion lives here and nowhere else.
+ */
+export const publishedPosts: readonly Post[] = [...posts]
+  .filter((post) => !post.draft)
+  .sort((a, b) => b.date.localeCompare(a.date));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"],
-      "@test/*": ["./test/*"]
+      "@test/*": ["./test/*"],
+      "#velite": ["./.velite"]
     }
   },
   "include": [

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, s } from 'velite';
+
+// Blog content pipeline (ADR-0008). The frontmatter schema is the contract:
+// invalid frontmatter fails `velite build`, and therefore `pnpm validate` and
+// the production build — never renders wrong.
+export default defineConfig({
+  collections: {
+    posts: {
+      name: 'Post',
+      pattern: 'blog/**/*.mdx',
+      schema: s
+        .object({
+          title: s.string().min(3).max(99),
+          // Hard cap keeps descriptions usable as meta descriptions (Stage 4).
+          description: s.string().min(10).max(160),
+          date: s.isodate(),
+          updated: s.isodate().optional(),
+          tags: s.array(s.string()).default([]),
+          draft: s.boolean().default(false),
+          slug: s.slug('blog'),
+          metadata: s.metadata(),
+          excerpt: s.excerpt(),
+          code: s.mdx(),
+        })
+        .transform((data) => ({ ...data, permalink: `/blog/${data.slug}` })),
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
       '@test': resolve(__dirname, 'test'),
       // Mirror the tsconfig `@/*` → ./src/* path for app imports.
       '@': resolve(__dirname, 'src'),
+      // Velite-generated blog content layer (run `pnpm content` first).
+      '#velite': resolve(__dirname, '.velite'),
     },
   },
   test: {


### PR DESCRIPTION
## What this lands

**Stage 1 of the blog build** (spec: `docs/blog/agentic-workflow.md`; brief: `docs/redesign/blog-handoff.md`):

- **Velite pipeline** (ADR-0008): `velite.config.ts` — posts collection from `content/blog/**/*.mdx`, Zod frontmatter contract (title 3–99, description 10–160, ISO dates, tags, draft, unique slug), derived reading time + excerpt + compiled MDX, `/blog/{slug}` permalinks. Invalid frontmatter fails the build.
- **Typed accessor** `src/content/blog.ts` mirroring the `cv.ts` house pattern — `publishedPosts` is the single public read; Draft exclusion lives there and nowhere else. Six schema-contract tests beside it.
- **Two seed Posts** — one published (with a code block for the Stage 2 highlighting test), one Draft.
- **Toolchain**: `#velite` alias (tsconfig + vitest), `.velite/` ignored in git/prettier/eslint/knip, `content`/`build`/`validate` scripts, CI "Build content layer" step, dev-only Velite watch in `next.config.ts` (explicit build in prod — no race), and the **three.js import ban** for blog code landed early.
- carnival-context Absorb: handoff doc updated to Stage 2 mission; journal paragraph appended.

## Fixes red master
`prettier --check .` covers HTML but lint-staged only formats json/css/md — the #72 brand-board HTMLs broke lint on master. They're formatted here; **merging this returns master to green**. Also sets `allowBuilds.esbuild: true` (velite transitive dep; the pnpm placeholder line broke `pnpm exec`).

## Verification
`pnpm validate` fully green: velite → typecheck → lint → 162 tests (26 files) → knip → `next build`.

**Next:** Stage 2 — `/blog` routes + reading template (first shipped brand surface; Utopia tokens land in `@theme`). Owed first: the monogram small-size pass (Nick's ruling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)