### PR TITLE
Blog Stage 5 — tag pages and Draft preview (final build stage)

### DIFF
--- a/docs/blog/blog-built.md
+++ b/docs/blog/blog-built.md
@@ -1,0 +1,176 @@
+# Blog — As-Built
+
+> **Status: built and shipped.** The blog is complete end-to-end across Stages 0, B, 1, 2, 4, 5
+> (Stage 3 was deleted under ADR-0011). This is the at-a-glance "what the blog IS now" doc: the
+> routes, the content pipeline, the SEO surfaces, the Draft and Tag model, and the single-read
+> contract that ties them together. Read this first; `docs/redesign/blog-handoff.md` behind it holds
+> the full build history, the stage-by-stage detail, and the gotchas.
+>
+> The one thing left is the **authoring pipeline** (`/publish-post` skill + `post-reviewer` agent).
+> That is how Posts get written and reviewed, a separate workstream, not a build stage. See §6.
+
+---
+
+## 0. TL;DR
+
+- A brand-styled build journal at **`/blog`** on the iamnick **Blueprint** brand (slate/fog, redline
+  accent, IBM Plex), self-contained from the carnival (ADR-0011). Index, Post reading template, tag
+  pages, and a dev-only Draft preview, plus the full SEO/discovery/social set.
+- **Content is MDX in the repo** (`content/blog/*.mdx`), compiled at build time by **Velite** into a
+  typed layer. No client-side MDX runtime, no client-side highlighter.
+- **One public read governs everything.** `publishedPosts` in `src/content/blog.ts` is the single
+  Draft-filtered source; the index, tag pages, sitemap and feeds all derive from it, so a Draft
+  cannot leak by construction.
+- Live seed content: **one published Post** (`building-this-blog-in-the-open`, Tags
+  `agentic-workflows` + `meta`) and **two Drafts** (`designing-the-publish-pipeline`,
+  `speccing-before-scaffolding`). Published Tags are `agentic-workflows` and `meta`.
+- Gate is `pnpm validate` (167 unit tests, knip clean, production build) plus the `@ci` Playwright
+  specs `e2e/blog.spec.ts` and `e2e/blog-seo.spec.ts`.
+
+---
+
+## 1. Routes (what exists)
+
+```
+src/app/blog/
+  layout.tsx              — brand shell + header (iam|nick|.dev treatment, blog breadcrumb).
+                            Loads the brand fonts; SiteNav stands down on /blog (ADR-0011).
+  page.tsx                — index. "Notes, measured twice." with the dimension underline;
+                            fig.-numbered Post list over publishedPosts. Static metadata
+                            (canonical /blog, RSS autodiscovery, OpenGraph website).
+  [slug]/page.tsx         — Post reading template. generateStaticParams over routablePosts,
+                            dynamicParams = false. brand-prose article via MdxContent; fig.
+                            meta row (Tags link out, middot separators); older/newer nav;
+                            BlogPosting JSON-LD (omitted for a previewed Draft).
+  [slug]/opengraph-image.tsx — per-Post OG card, Blueprint palette, real brand fonts vendored
+                            as woff (Satori reads neither Tailwind nor @theme). SSG per
+                            published Post; a Draft slug gets no card.
+  tags/[tag]/page.tsx     — tag page. Kicker + #tag with the dimension underline, fig-less Post
+                            list. generateStaticParams over publishedTags, dynamicParams = false,
+                            so an unknown or Draft-only Tag 404s. generateMetadata: canonical +
+                            OpenGraph per Tag.
+  rss.xml/route.ts        — hand-rolled RSS 2.0 (dynamic = 'force-static', published only,
+                            XML-escaped). No feed dependency.
+
+src/app/sitemap.ts        — /blog, each published Post (lastModified from updated ?? date), and
+                            each published Tag URL (/blog/tags/[tag]).
+
+src/components/blog/
+  MdxContent.tsx          — Velite compiled-function-body renderer (the documented react-hooks
+                            inline disable lives here; it is compiled-MDX's core mechanism).
+  BlogPostingJsonLd.tsx   — BlogPosting JSON-LD (mirrors the CV JsonLd Person pattern; author +
+                            publisher = Nick; image → the co-located OG route; keywords from Tags).
+```
+
+Brand styling lives in `src/styles/globals.css`: the `@theme` block carries the brand-prefixed
+Utopia type/space tokens (320→1240px, body 18→21px, ratio 1.2→1.25), `.brand-surface`,
+`.brand-prose` (including the Shiki `pre` overrides), and the `brand-underline` utility. Brand fonts
+(IBM Plex Sans/Mono via `next/font`) are in `src/lib/fonts/brand.ts`, loaded only by the blog
+layout. `docs/brand/brand.md` is the visual source of truth.
+
+---
+
+## 2. Content pipeline
+
+```
+content/blog/*.mdx  ──Velite (build + dev watch)──►  generated typed output (#velite alias)
+                                                            │
+                                              src/content/blog.ts (typed accessors)
+```
+
+- **Velite** (`velite.config.ts`) reads `content/blog/**/*.mdx`, validates a Zod frontmatter
+  contract (`title` 3–99, `description` 10–160, isodate `date`/`updated`, `tags` default `[]`,
+  `draft` default `false`, unique `slug`, derived reading time + excerpt + compiled MDX,
+  `permalink` → `/blog/{slug}`). **Invalid frontmatter fails the build** (`pnpm content`, therefore
+  `pnpm validate` and the production build).
+- **Shiki at build time** (`@shikijs/rehype`, `github-dark-default`) in the Velite MDX options. No
+  client-side highlighter ships; the standalone `shiki` package is not a dependency.
+- Toolchain: `#velite` path alias; `.velite/` ignored in git/prettier/eslint/knip; scripts `content`
+  (`velite build`) and `build` (`velite build && next build`); `validate` prepends `pnpm content`;
+  `next.config.ts` starts the Velite watch in dev only.
+
+---
+
+## 3. The Draft and Tag model: the single-read contract
+
+`src/content/blog.ts` is the whole model. Everything public derives from **`publishedPosts`**:
+
+| Accessor           | Reads            | Purpose                                                                                           |
+| ------------------ | ---------------- | ------------------------------------------------------------------------------------------------- |
+| `allPosts`         | Velite output    | Dev/tests only. Never a public read.                                                              |
+| `publishedPosts`   | `allPosts`       | **The** public read: Draft-filtered, newest-first. Index, tag pages, sitemap, RSS, OG all use it. |
+| `routablePosts`    | `publishedPosts` | The Post route's param source only. `publishedPosts` in production; `+ Drafts` in `next dev`.     |
+| `publishedTags`    | `publishedPosts` | Unique, alphabetical Tags on published Posts. Drives tag-page params + sitemap.                   |
+| `postsForTag(tag)` | `publishedPosts` | Published Posts carrying a Tag, newest-first.                                                     |
+
+- **Draft exclusion by construction.** Because `publishedTags` and `postsForTag` read
+  `publishedPosts`, a Draft-only Tag (`process`, carried only by the `speccing-before-scaffolding`
+  Draft) never gets a page or a sitemap entry.
+- **Draft preview is dev-only.** `routablePosts` gates on `process.env.NODE_ENV !== 'production'`. In
+  `next dev` a Draft is reachable at its URL with a "Draft. Visible only in local development, never
+  in production." banner and no JSON-LD. Production **and Vercel preview** builds run
+  `NODE_ENV=production`, so they exclude Drafts too. The preview is a local affordance, not a staging
+  one. Only the Post route reads `routablePosts`; everything else stays on `publishedPosts`.
+- **Tags link from the Post, not the index.** The Post meta row links each Tag to `/blog/tags/[tag]`.
+  The index leaves Tags as text because the whole Post row is already a link and a link cannot nest.
+
+Live seed reality: `building-this-blog-in-the-open.mdx` published (Tags `agentic-workflows` +
+`meta`); `designing-the-publish-pipeline.mdx` Draft (Tag `agentic-workflows`);
+`speccing-before-scaffolding.mdx` Draft (Tags `agentic-workflows` + `process`). Published Tags:
+`agentic-workflows`, `meta`.
+
+---
+
+## 4. SEO, discovery and social surfaces
+
+All read `publishedPosts` and nothing else, so a Draft cannot enter a feed, sitemap or card.
+
+- **Metadata** — static on the index (canonical, RSS autodiscovery, OpenGraph website);
+  `generateMetadata` on each Post from frontmatter (canonical, OpenGraph article with
+  published/modified time, authors, Tags, Twitter `summary_large_image`); `generateMetadata` on each
+  tag page (canonical + OpenGraph).
+- **OG cards** — per-Post at `[slug]/opengraph-image.tsx`, Blueprint palette, real brand fonts
+  vendored to `src/assets/fonts/ibm-plex-*.woff`, all-inline styling. SSG per published Post.
+- **JSON-LD** — `BlogPosting` per Post (omitted for a previewed Draft).
+- **Sitemap** — `/blog`, each published Post, each published Tag URL.
+- **RSS** — hand-rolled RSS 2.0 at `/blog/rss.xml`, published only.
+
+---
+
+## 5. Where the specs, decisions and history live
+
+- **Build handoff (full history + gotchas):** `docs/redesign/blog-handoff.md`.
+- **Build journal (one dated paragraph per stage):** `docs/blog/journal.md`.
+- **What launch must include:** `docs/blog/prd.md`.
+- **How each stage ran + the authoring pipeline spec:** `docs/blog/agentic-workflow.md`.
+- **Decision log:** `docs/blog/discovery.md` (rows 1–19).
+- **ADRs (all accepted):** 0008 (Velite typed MDX), 0009 (Utopia fluid type/space, brand-scoped),
+  0010 (agentic delivery workflow + two-component hard cap), 0011 (brand separation).
+- **Look:** `docs/brand/brand.md`, `docs/brand/boards/concept-c-blueprint.html`.
+- **Glossary:** `CONTEXT.md` (Blog, Post, Tag, Draft, in plain English, no carnival register).
+
+---
+
+## 6. What remains: the authoring pipeline (separate workstream)
+
+The blog **surface** is built. What is not built is how Posts get written and reviewed, specified in
+ADR-0010 and `docs/blog/agentic-workflow.md`:
+
+- **`/publish-post` skill** — scaffold a Post from an idea, enforce the frontmatter contract, warn on
+  a new Tag (the vocabulary is kept deliberately small).
+- **`post-reviewer` agent** — a voice + `avoid-ai-writing` pass on a draft Post before Nick merges.
+
+These are the **only two** `.claude` components the blog is allowed (ADR-0010's two-component hard
+cap). Publishing stays Nick's act: Nick drafts, AI edits, publishing is Nick flipping `draft: false`
+and merging the PR. This work is Nick's to kick off, and it runs as its own workstream, not as
+another blog build stage.
+
+---
+
+## 7. Quick orientation for a fresh session
+
+1. Read this doc, then `docs/redesign/blog-handoff.md` §7 (gotchas) if you are touching the build.
+2. `src/content/blog.ts` is the whole Draft/Tag model; start there.
+3. `pnpm dev`, open `/blog`, `/blog/[slug]`, `/blog/tags/agentic-workflows`, and a Draft URL (banner
+   in dev, 404 in a production build).
+4. Gate any change with `pnpm validate` + the `@ci` specs `e2e/blog.spec.ts`, `e2e/blog-seo.spec.ts`.

--- a/docs/blog/journal.md
+++ b/docs/blog/journal.md
@@ -62,3 +62,23 @@ made that single Post the fixture the SEO contract tests pin to. The lesson wort
 content state is now part of the test surface, not just the pages. One quiet win to close on: RSS
 was hand-rolled instead of pulled from a package, so knip stayed green and nothing new entered the
 tree.
+
+**2026-07-23 — Stage 5, tag pages and Draft polish.** The last build stage, and it closed cleanly.
+Tag pages, the Draft preview held over from Stage 2, and the sitemap Tag URLs held back at Stage 4
+all went on together, and every one of them still resolved through the same `publishedPosts` read
+that has carried the Draft-exclusion contract since Stage 1. The tag route derives `publishedTags`
+and `postsForTag` from that one list, so the whole model fell out for free: a Draft-only Tag like
+`process` gets no page, no sitemap entry, no way to surface, because it was never in the list to
+begin with. Two decisions worth keeping. The Draft preview is a local `next dev` affordance gated on
+`NODE_ENV`, not a staging one, because Vercel preview builds run as production and should hide Drafts
+exactly as production does, so only the Post route reads the preview list and everything else stays
+on `publishedPosts`. And the index leaves its Tags as plain text while the Post page links them,
+because the index row is already one link to the Post and HTML forbids a link inside a link, a small
+constraint that quietly settled where Tag links belong. The one surprise was carried over from the
+same day's OG-card fix rather than the tag work: Satori renders the social card through neither
+Tailwind nor the `@theme` tokens nor `next/font`, so the brand faces had to be vendored as raw woff
+and the card styled entirely inline, which Nick ruled is simply how a Satori card works. A tidy note
+to end the build on: the fig. separator moved from an em dash to a middot, the voice rule reaching
+even the punctuation between two numbers. The blog surface is complete. What is left, the
+`/publish-post` skill and the `post-reviewer` agent, is how Posts get written, a separate workstream,
+not another stage.

--- a/docs/redesign/blog-handoff.md
+++ b/docs/redesign/blog-handoff.md
@@ -1,16 +1,17 @@
 # Blog — Build Handoff
 
-> **Mission for the next session:** build **Stage 5 — Tag pages + Draft polish**. Tag routes
-> (`/blog/tags/[tag]`) over `publishedPosts`, the draft-preview mechanism (deferred from Stage 2),
-> then the sitemap tag URLs that Stage 4 held back until tag pages existed. Docs-scribe close-out:
-> this doc gains a shipped-state summary in the `ball-toss-game-built.md` pattern.
+> **The blog build is COMPLETE.** All stages have shipped (0, B, 1, 2, 4, 5; Stage 3 was deleted
+> under ADR-0011). For the at-a-glance shipped state — routes, content pipeline, SEO surfaces, the
+> Draft/Tag model and the single-read contract — read **`docs/blog/blog-built.md` first**; it is the
+> as-built summary. This handoff keeps the full build history and gotchas behind it.
 >
-> Stage 4 (SEO surfaces) landed and merged. Stage 2 merged as PR #74, so its two human gates are
-> moot.
+> **What remains is not a build stage.** The authoring pipeline (`/publish-post` skill +
+> `post-reviewer` agent, ADR-0010) is a separate workstream: it is how Posts get written and
+> reviewed, not how the blog surface gets built. See §9.
 >
 > Specs are done and live in `docs/blog/`; this doc points at them and adds only build-facing
-> operational detail. Read `CONTEXT.md` first (Blog/Post/Tag/Draft entries). Each stage gets its
-> own branch and a PR to master. The site is live, so every slice must leave production shippable.
+> operational detail. Read `CONTEXT.md` first (Blog/Post/Tag/Draft entries). Each stage got its
+> own branch and a PR to master. The site is live, so every slice left production shippable.
 
 ---
 
@@ -19,11 +20,12 @@
 1. Read the spec set: `docs/blog/discovery.md` (decision log, rows 1–19), `docs/blog/prd.md` (what
    launch must include), `docs/blog/agentic-workflow.md` (how each stage runs and gates). ADRs
    0008–0011 are all **accepted** and binding.
-2. Stage order: **0 ✅ → B ✅ → 1 ✅ → 2 ✅ → 4 ✅ → 5** (Stage 3 deleted, ADR-0011; numbering preserved).
-3. Every stage is bracketed by carnival-context **Brief** before and **Absorb** after; Absorb also
+2. Stage order: **0 ✅ → B ✅ → 1 ✅ → 2 ✅ → 4 ✅ → 5 ✅** — all shipped (Stage 3 deleted,
+   ADR-0011; numbering preserved).
+3. Every stage was bracketed by carnival-context **Brief** before and **Absorb** after; Absorb also
    appends a dated paragraph to `docs/blog/journal.md`.
-4. Stage 5 next (see §8). Do not duplicate spec content into code comments or this doc; the specs
-   are the source.
+4. Build complete (see §8, §9). What is left is the authoring pipeline, a separate workstream. Do
+   not duplicate spec content into code comments or this doc; the specs are the source.
 
 ---
 
@@ -46,17 +48,24 @@
   `s.metadata()` reading time, `s.excerpt()`, `s.mdx()` compiled output, permalink transform
   `/blog/{slug}`). Invalid frontmatter fails `velite build`, therefore `pnpm validate` and the
   production build.
-- **Typed accessor**: `src/content/blog.ts` — `allPosts` (dev/tests only) and `publishedPosts`
-  (**the** single public read: Draft-filtered, newest-first), with `src/content/blog.test.ts`
-  beside it (6 tests: published non-empty, Draft never leaks, ordering, slug/permalink
-  uniqueness + shape, frontmatter contract, derived reading time + compiled MDX).
-- **Seed Posts** in `content/blog/`: after the Stage 2 merge only **one** is published,
-  `building-this-blog-in-the-open.mdx` (carries a code block as the highlighting test).
-  `designing-the-publish-pipeline.mdx` and `speccing-before-scaffolding.mdx` are both Drafts
-  (`speccing…` was flipped to Draft in the Stage 2 merge, commit 28ec0e7). Consequence for the
-  suite: `blog.spec.ts` prev/next now **skips** because it needs two published Posts, and the Stage
-  4 SEO tests pin `building-this-blog-in-the-open` as the published fixture with the other two as
-  the Draft-never-leaks fixtures. Restoring a second published Post un-skips prev/next; see §7.
+- **Typed accessor**: `src/content/blog.ts` — `allPosts` (dev/tests only), `publishedPosts`
+  (**the** single public read: Draft-filtered, newest-first), and since Stage 5 three more reads that
+  all derive from `publishedPosts`: `publishedTags` (unique, alphabetical, Tags on published Posts
+  only), `postsForTag(tag)` (published Posts carrying a Tag, newest-first), and `routablePosts` (the
+  Post route's param source: `publishedPosts` in production, `publishedPosts` + Drafts in `next dev`
+  via a `NODE_ENV !== 'production'` gate). `src/content/blog.test.ts` beside it now runs the tag and
+  Draft-preview cases too (a Draft-only Tag never surfaces; `routablePosts` previews Drafts outside
+  production while `publishedPosts` hides them).
+- **Seed Posts** in `content/blog/`: **one published**,
+  `building-this-blog-in-the-open.mdx` (Tags `agentic-workflows` + `meta`; carries a code block as the
+  highlighting test). Two Drafts: `designing-the-publish-pipeline.mdx` (Tag `agentic-workflows`) and
+  `speccing-before-scaffolding.mdx` (Tags `agentic-workflows` + `process`). **Published Tags** are
+  therefore `agentic-workflows` and `meta`; `process` is a Draft-only Tag and gets no page or sitemap
+  entry. Consequence for the suite: `blog.spec.ts` prev/next **skips** (needs two published Posts),
+  the SEO tests pin `building-this-blog-in-the-open` as the published fixture with the two Drafts as
+  the never-leaks fixtures, and the tag tests use `agentic-workflows`/`meta` as the published Tags and
+  `process` as the Draft-only Tag that must 404. Restoring a second published Post un-skips prev/next;
+  see §7.
 - **Toolchain wired**: `#velite` path alias (tsconfig + vitest); `.velite/` ignored in
   git/prettier/eslint/knip; knip entry `velite.config.ts`; scripts `content` (`velite build`) and
   `build` (`velite build && next build`); `validate` prepends `pnpm content`; CI has a "Build
@@ -98,8 +107,24 @@
   (`dynamic = 'force-static'`, published only, XML-escaped, `application/rss+xml`, no new
   dependency). Gates green: `pnpm content` + `pnpm typecheck` + `pnpm lint` + `pnpm test:ci` (162
   unit) + `pnpm knip` + `pnpm build`, plus the new `@ci` spec `e2e/blog-seo.spec.ts` 6/6.
-- **Branch state**: Stage 2 merged to master as **PR #74**; Stage 1 was PR #73, Stage 0 PR #72.
-  Master is green. Stage 4 sits on `feature/blog-stage-4`.
+- **Tag pages + Draft preview live** (Stage 5, 2026-07-23, `feature/blog-stage-5`, commit 52f8411):
+  `src/app/blog/tags/[tag]/page.tsx` — brand-styled like the index (kicker + `#tag` with the
+  dimension underline, fig-less Post list), SSG via `generateStaticParams` over `publishedTags` with
+  `dynamicParams = false` so an unknown or Draft-only Tag 404s, and `generateMetadata` for a canonical
+  - OpenGraph per Tag. The Post meta row now links each Tag to its page; the index leaves Tags as text
+    (the whole row is already a link to the Post, and a link cannot nest). **Draft preview**: only the
+    Post route reads `routablePosts`, so in `next dev` a Draft is reachable at its URL with a "Draft.
+    Visible only in local development, never in production." banner and no `BlogPosting` JSON-LD;
+    production and Vercel preview builds (both `NODE_ENV=production`) exclude it. `src/app/sitemap.ts`
+    now emits `/blog/tags/[tag]` for each published Tag (the URLs Stage 4 deferred). Polish: the fig.
+    meta separator on the index and Post pages moved from an em dash to a middot (voice rule). Gate
+    green: `pnpm validate` (167 unit, knip clean, build prerenders only published surfaces) plus the
+    extended `@ci` specs — `blog.spec.ts` (tag page renders its published Posts, unknown + Draft-only
+    Tag 404, Post tags link out) and `blog-seo.spec.ts` (sitemap carries published Tag URLs, not
+    `process`). Draft preview verified live: 200 + banner in `next dev`, 404 in the production build.
+- **Branch state**: Stage 4 merged to master as **PR #76**; Stage 2 was PR #74, Stage 1 PR #73,
+  Stage 0 PR #72. Master is green. Stage 5 sits on `feature/blog-stage-5` (commit 52f8411), awaiting
+  its PR to master.
 
 ## 2. Integration map
 
@@ -111,9 +136,9 @@ content/blog/*.mdx  ──Velite (build/watch)──►  generated typed output
                                                     │
               ┌─────────────────────────────────────┼──────────────────────────┐
         /blog + /blog/[slug]                  /blog/tags/[tag]           SEO surfaces
-        (Stage 2 ✅ — brand tokens          (Stage 5)                (Stage 4 ✅: metadata,
-         live in @theme)                                              OG, JSON-LD,
-                                                                      sitemap, RSS)
+        (Stage 2 ✅ — brand tokens          (Stage 5 ✅ — tag        (Stage 4 ✅: metadata,
+         live in @theme; Post route          pages + Draft            OG, JSON-LD,
+         reads routablePosts, Stage 5)        preview)                sitemap + tag URLs, RSS)
 ```
 
 Touchpoints with the existing tree: `src/styles/globals.css` `@theme` block (brand-prefixed Utopia
@@ -162,9 +187,10 @@ Full log with rationale: `docs/blog/discovery.md` rows 1–19. The build-facing 
 | Nick drafts, AI edits, publishing is Nick merging the PR                               | ADR-0010 (Nick's word)             |
 
 Settled at Stage 2: Utopia scale parameters (320→1240px, body 18→21px, ratio 1.2→1.25 — in
-`@theme`, subject only to Nick's reading-feel gate). Still deferred (do not decide early): draft
-preview mechanism → Stage 5 brief; tag vocabulary → emerges from first posts; first-load JS
-**budget** → baseline now recorded (§7), the budget number itself remains open.
+`@theme`, subject only to Nick's reading-feel gate). Settled at Stage 5: the draft preview mechanism
+(dev-only `routablePosts`, `NODE_ENV` gate, read by the Post route alone) and the tag route shape.
+Still open: tag vocabulary keeps emerging from real Posts (three published/Draft Tags so far); the
+first-load JS **budget** number (baseline recorded, §7).
 
 ## 6. How to verify
 
@@ -174,8 +200,10 @@ preview mechanism → Stage 5 brief; tag vocabulary → emerges from first posts
   block, prev/next, draft slug 404s), plus the verify skill and **Nick reads the feel** (human gate).
 - **Stage 4:** `@ci` contract assertions in the `api.spec.ts` style — RSS valid XML excluding
   Drafts, sitemap contains post URLs, JSON-LD parses, OG route returns an image.
-- **Stage 5:** extended `@ci` blog spec (tag pages correct; Draft absent from index/RSS/sitemap,
-  previewable in dev).
+- **Stage 5 ✅:** extended `@ci` specs — `blog.spec.ts` (tag page lists only its published Posts,
+  unknown + Draft-only Tag 404, Post Tags link out) and `blog-seo.spec.ts` (sitemap carries published
+  Tag URLs, not `process`), plus a live check that a Draft is 200 + banner in `next dev` and 404 in
+  the production build.
 - Blog pages are plain DOM — no headless-canvas screenshot rig needed; standard Playwright suffices.
 
 ## 7. Gotchas
@@ -216,14 +244,20 @@ preview mechanism → Stage 5 brief; tag vocabulary → emerges from first posts
   `brand.md`, px widths), never classNames or `ch` units — a `ch`-based title width collapsed the
   wrap to one word per line the first time. Nick ruled all-inline is correct here (2026-07-23); the
   carnival `/opengraph-image` sets the same precedent.
-- **Seed content drift, and the tests that pin it** (Stage 4) — with only one published Post,
-  `blog.spec.ts` prev/next skips (needs two) and the SEO contract tests hardcode
-  `building-this-blog-in-the-open` as the published fixture and the two Drafts as the
-  never-leaks fixtures. If Stage 5 changes which seeds are published, both suites move with it. See
-  §1.
-- **Sitemap tag URLs deliberately deferred to Stage 5** — tag pages do not exist yet, so no sitemap
-  entry points at a 404. Stage 5 adds the tag routes first, then their sitemap URLs. `src/app/
-sitemap.ts` carries the marker comment where they go.
+- **Seed content drift, and the tests that pin it** (Stage 4, still live at Stage 5) — with only one
+  published Post, `blog.spec.ts` prev/next skips (needs two) and the SEO contract tests hardcode
+  `building-this-blog-in-the-open` as the published fixture and the two Drafts as the never-leaks
+  fixtures. Stage 5 added tag fixtures on the same footing: `agentic-workflows`/`meta` are the
+  published Tags, `process` is the Draft-only Tag the tests assert must 404 and stay out of the
+  sitemap. Any change to which seeds are published moves all three suites. See §1.
+- **Draft preview is dev-only by a `NODE_ENV` gate, not a build flag** (Stage 5) — `routablePosts`
+  previews Drafts only when `process.env.NODE_ENV !== 'production'`. Vercel preview deployments build
+  with `NODE_ENV=production`, so they correctly hide Drafts too; the preview is a **local `next dev`**
+  affordance, not a staging one. Only the Post route reads `routablePosts`; the index, tags, sitemap
+  and feeds stay on `publishedPosts`, so the single-read Draft-exclusion contract still holds.
+- **Sitemap tag URLs — done** (was deferred Stage 4 → Stage 5). `src/app/sitemap.ts` now maps
+  `publishedTags` to `/blog/tags/[tag]`, so every emitted Tag URL has a real SSG page behind it and a
+  Draft-only Tag (`process`) never appears. The Stage 4 marker comment is gone.
 - **Brand monogram small-size pass done, ruling pending** — three variants rendered in
   `docs/brand/boards/monogram-pass.{html,png}`: V1 (heavier stems, dash kept), V2 (points, no
   dash — cleanest at 16px), V3 (measured cut — boldest at large, muddy ≤32px). Nick rules the
@@ -240,40 +274,61 @@ sitemap.ts` carries the marker comment where they go.
 3. ~~**Stage 4 — SEO surfaces**~~ ✅ done (2026-07-23, `feature/blog-stage-4`): `generateMetadata`
    for index + Posts, per-Post OG card, `BlogPosting` JSON-LD, sitemap extension, RSS. Full gate
    green plus `e2e/blog-seo.spec.ts` 6/6. See §1.
-4. **Stage 5 — tag pages + Draft polish** (next): `/blog/tags/[tag]` over `publishedPosts`, the
-   draft-preview mechanism deferred from Stage 2, then the sitemap tag URLs Stage 4 held back.
-   Docs-scribe close-out; this doc gains a shipped-state summary (the `ball-toss-game-built.md`
-   pattern).
+4. ~~**Stage 5 — tag pages + Draft polish**~~ ✅ done (2026-07-23, `feature/blog-stage-5`, commit
+   52f8411): `/blog/tags/[tag]` over `publishedPosts`, the draft-preview mechanism deferred from
+   Stage 2 (`routablePosts`, dev-only), then the sitemap tag URLs Stage 4 held back. `pnpm validate`
+   green (167 unit), `@ci` blog + SEO specs extended and passing. See §1, §9. Shipped-state summary
+   written to `docs/blog/blog-built.md`.
 
-Every stage: carnival-context Brief before, Absorb after, journal paragraph appended to
-`docs/blog/journal.md`. Branch per stage, PR to master.
+**The blog build is COMPLETE** — Stages 0, B, 1, 2, 4, 5 all shipped (Stage 3 deleted, ADR-0011).
+Every stage ran carnival-context Brief before, Absorb after, journal paragraph appended to
+`docs/blog/journal.md`, branch per stage, PR to master. What remains is the authoring pipeline (§9),
+a separate workstream, not a build stage.
 
 ## 9. What just happened
 
-**Stage 4 built and gated** (2026-07-23, `feature/blog-stage-4`). Every public SEO surface landed
-against the single `publishedPosts` read: static index `metadata`, per-Post `generateMetadata` off
-frontmatter, a Blueprint-branded per-Post OG card, `BlogPosting` JSON-LD (the CV `JsonLd` Person
-pattern mirrored), the sitemap extension, and a hand-rolled RSS 2.0 route with no new dependency.
-The OG card holds the ADR-0011 boundary on purpose, so it is the Blueprint palette (slate, steel
-margin, redline underline, wordmark with the red `.dev`) rather than the carnival poster. Full gate
-green, plus a new `@ci` spec `e2e/blog-seo.spec.ts` 6/6.
+**Stage 5 built and gated, the final build stage** (2026-07-23, `feature/blog-stage-5`, commit
+52f8411). Tag pages, the Draft preview deferred from Stage 2, and the sitemap tag URLs Stage 4 held
+back all landed together, each still resolving through the single `publishedPosts` read. The tag
+route (`src/app/blog/tags/[tag]/page.tsx`) is brand-styled like the index, SSG over `publishedTags`
+with `dynamicParams = false`, so an unknown or Draft-only Tag 404s and each Tag page carries its own
+canonical + OpenGraph. Post meta-row Tags now link out; the index leaves them as text because the
+whole row is already a Post link and a link cannot nest. The Draft preview is a dev-only affordance:
+`routablePosts` gates on `NODE_ENV`, the Post route alone reads it, and a Draft shows at its URL in
+`next dev` with a banner and no JSON-LD while production and Vercel preview builds exclude it. The
+sitemap now emits every published Tag URL, and the fig. meta separator moved from an em dash to a
+middot to hold the voice rule. Gate green: `pnpm validate` (167 unit, knip clean, build prerenders
+only published surfaces), the extended `@ci` blog + SEO specs, and a live check that the Draft is 200
 
-Two build seams became gotchas (§7). Next 16 refuses `runtime = 'edge'` on a metadata image route
-that also has `generateStaticParams`, so the per-Post card runs the Node default while the root
-carnival OG keeps edge. And the seed set had drifted under us: the Stage 2 merge left only one
-published Post, so `blog.spec.ts` prev/next skips and the SEO tests pin
-`building-this-blog-in-the-open` as the published fixture with the two Drafts as the never-leaks
-fixtures. Sitemap tag URLs were held back to Stage 5 so nothing points at a tag 404 before those
-pages exist.
+- banner in `next dev` and 404 in the production build.
 
-Before this, Stage 2 (`feature/blog-stage-2`) merged as **PR #74**, which cleared its two human
-gates and made them moot.
+Also folded in this day: the **Stage 4 OG-card follow-up**. The per-Post card was re-cut to render in
+the real brand fonts (Montserrat wordmark, Plex Sans title, Plex Mono labels, all vendored as local
+woff in `src/assets/fonts/`) with explicit px widths so the title wraps as a sentence. Satori cannot
+read Tailwind or the `@theme` tokens, so Nick ruled the card stays all-inline (§7).
+
+**The blog build is now COMPLETE** — Stages 0, B, 1, 2, 4, 5 all shipped (Stage 3 deleted under
+ADR-0011). The public surface is done: index, Post reading template, tag pages, Draft preview, and
+the full SEO/discovery/social set, all on the single-read contract. The as-built summary is
+`docs/blog/blog-built.md`; read it first from here on.
+
+**What is left is the authoring pipeline, and it is a separate workstream, not a build stage.**
+ADR-0010 specifies a `/publish-post` skill (scaffold a Post from an idea, enforce the frontmatter
+contract, warn on a new Tag) and a `post-reviewer` agent (voice + `avoid-ai-writing` pass on a draft
+Post before Nick merges). Neither is built. They are how Posts get _written and reviewed_, not how
+the blog surface gets _built_, so they sit outside the staged build and outside this handoff's remit.
+The two-component hard cap (ADR-0010) means these are the only two `.claude` components the blog is
+allowed. `docs/blog/agentic-workflow.md` holds the spec.
 
 ### Needs Nick
 
-- **OG card feel** — the per-Post social card shipped in the Blueprint palette without a look
-  ruling. When Nick has a moment, check a live card (`/blog/building-this-blog-in-the-open/
-opengraph-image`) and say whether the composition holds. Not a blocker; a share preview is not on
-  the critical path, but it is a public visual surface and the feel is Nick's call.
-- **Nothing else outstanding.** The Stage 2 gates (reading feel, monogram ruling) cleared on the
-  PR #74 merge.
+- **OG card feel** — the per-Post social card now renders in the real brand fonts, but the
+  composition still has no explicit look ruling. When Nick has a moment, check a live card
+  (`/blog/building-this-blog-in-the-open/opengraph-image`) and say whether it holds. Not a blocker; a
+  share preview is off the critical path, but it is a public visual surface and the feel is Nick's
+  call.
+- **Merge `feature/blog-stage-5`** — Stage 5 is gated green on its branch and awaits its PR to
+  master (the last build PR). Merging it is Nick's, as every stage merge has been.
+- **Kick off the authoring pipeline when ready** — building `/publish-post` + `post-reviewer` is the
+  next natural piece of work, but it is Nick's call when to start it and it runs as its own workstream
+  under ADR-0010, not as a blog build stage.

--- a/e2e/blog-seo.spec.ts
+++ b/e2e/blog-seo.spec.ts
@@ -28,6 +28,16 @@ test.describe('blog SEO surfaces', { tag: '@ci' }, () => {
     }
   });
 
+  test('sitemap lists Tag pages carried by a published Post, not Draft-only Tags', async ({
+    request,
+  }) => {
+    const res = await request.get(`${ORIGIN}/sitemap.xml`);
+    const xml = await res.text();
+    expect(xml).toContain(`${SITE}/blog/tags/agentic-workflows`);
+    // "process" sits only on a Draft, so its Tag page does not exist.
+    expect(xml).not.toContain('/blog/tags/process');
+  });
+
   test('RSS is well-formed, published-only, and served as RSS', async ({ request }) => {
     const res = await request.get(`${ORIGIN}/blog/rss.xml`);
     expect(res.status()).toBe(200);

--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test } from '@playwright/test';
 
 /**
- * Blog surface (Stage 2 gate — docs/redesign/blog-handoff.md §6). Plain DOM,
- * no canvas: safe for the @ci subset. Seed content: two published Posts and
- * one Draft (designing-the-publish-pipeline).
+ * Blog surface (docs/redesign/blog-handoff.md §6). Plain DOM, no canvas, safe
+ * for the @ci subset. Seed content: one published Post
+ * (building-this-blog-in-the-open) and two Drafts (designing-the-publish-pipeline,
+ * speccing-before-scaffolding).
  */
 test.describe('blog', { tag: '@ci' }, () => {
   test('index lists published Posts, newest first', async ({ page }) => {
@@ -52,5 +53,27 @@ test.describe('blog', { tag: '@ci' }, () => {
     await expect(page.locator('canvas')).toHaveCount(0);
     // The carnival SiteNav stands down on brand surfaces (ADR-0011).
     await expect(page.getByRole('button', { name: 'Open menu' })).toHaveCount(0);
+  });
+
+  test('a tag page lists only its published Posts', async ({ page }) => {
+    await page.goto('/blog/tags/agentic-workflows');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('agentic-workflows');
+    await expect(page.getByRole('heading', { level: 2 })).toContainText(
+      'Building this blog in the open',
+    );
+    // speccing-before-scaffolding carries the tag but is a Draft, so it is absent.
+    await expect(page.getByText('Speccing before scaffolding')).toHaveCount(0);
+  });
+
+  test('an unknown tag and a Draft-only tag both 404', async ({ page }) => {
+    expect((await page.goto('/blog/tags/definitely-not-a-tag'))?.status()).toBe(404);
+    // "process" sits only on a Draft, so it never becomes a page.
+    expect((await page.goto('/blog/tags/process'))?.status()).toBe(404);
+  });
+
+  test('a Post links its tags to the tag pages', async ({ page }) => {
+    await page.goto('/blog/building-this-blog-in-the-open');
+    await page.getByRole('link', { name: 'agentic-workflows' }).first().click();
+    await expect(page).toHaveURL(/\/blog\/tags\/agentic-workflows$/);
   });
 });

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,27 +4,30 @@ import { notFound } from 'next/navigation';
 
 import { BlogPostingJsonLd } from '@/components/blog/BlogPostingJsonLd';
 import { MdxContent } from '@/components/blog/MdxContent';
-import { publishedPosts } from '@/content/blog';
+import { publishedPosts, routablePosts } from '@/content/blog';
 
 interface PostPageProps {
   params: Promise<{ slug: string }>;
 }
 
-/** Published Posts only — a Draft slug is a 404, never a page. */
+/** Production: published Posts only. `next dev` also routes Drafts for preview
+ *  (routablePosts). Either way an unknown slug 404s (dynamicParams = false). */
 export function generateStaticParams() {
-  return publishedPosts.map((post) => ({ slug: post.slug }));
+  return routablePosts.map((post) => ({ slug: post.slug }));
 }
 
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: PostPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const post = publishedPosts.find((p) => p.slug === slug);
+  const post = routablePosts.find((p) => p.slug === slug);
   if (!post) return {};
 
   return {
     title: post.title,
     description: post.description,
+    // A Draft only reaches here in dev; keep it out of any index if ever crawled.
+    ...(post.draft && { robots: { index: false, follow: false } }),
     alternates: {
       canonical: post.permalink,
       types: { 'application/rss+xml': [{ url: '/blog/rss.xml', title: "Nick's rambles" }] },
@@ -52,30 +55,50 @@ const formatDate = (iso: string) =>
 
 export default async function PostPage({ params }: PostPageProps) {
   const { slug } = await params;
-  const index = publishedPosts.findIndex((post) => post.slug === slug);
-  if (index === -1) notFound();
+  const post = routablePosts.find((p) => p.slug === slug);
+  if (!post) notFound();
 
-  const post = publishedPosts[index];
-  // publishedPosts is newest-first: "newer" sits earlier in the list.
-  const newer = index > 0 ? publishedPosts[index - 1] : undefined;
-  const older = index < publishedPosts.length - 1 ? publishedPosts[index + 1] : undefined;
+  // fig. number and prev/next live on the published sequence; a Draft preview has
+  // neither (it never joins the public order).
+  const publishedIndex = publishedPosts.findIndex((p) => p.slug === slug);
+  const figNumber =
+    publishedIndex >= 0 ? String(publishedPosts.length - publishedIndex).padStart(2, '0') : '--';
+  const newer = publishedIndex > 0 ? publishedPosts[publishedIndex - 1] : undefined;
+  const older =
+    publishedIndex >= 0 && publishedIndex < publishedPosts.length - 1
+      ? publishedPosts[publishedIndex + 1]
+      : undefined;
 
   return (
     <article>
-      <BlogPostingJsonLd post={post} />
+      {post.draft ? (
+        <p className="mb-brand-l border-l-2 border-brand-red bg-brand-panel px-brand-s py-brand-2xs font-brand-mono text-brand-xs text-brand-red-bright">
+          Draft. Visible only in local development, never in production.
+        </p>
+      ) : (
+        <BlogPostingJsonLd post={post} />
+      )}
       <header>
         <p className="font-brand-mono text-brand-xs uppercase tracking-[0.22em] text-brand-fog">
-          <span className="normal-case text-brand-red-bright">
-            fig. {String(publishedPosts.length - index).padStart(2, '0')}
-          </span>
-          {' — '}
+          <span className="normal-case text-brand-red-bright">fig. {figNumber}</span>
+          {' · '}
           <time dateTime={post.date}>{formatDate(post.date)}</time>
           {' · '}
           {Math.max(1, Math.round(post.metadata.readingTime))} min
           {post.tags.length > 0 && (
             <>
-              {' '}
-              {' · '} {post.tags.join(', ')}
+              {' · '}
+              {post.tags.map((tag, i) => (
+                <span key={tag}>
+                  {i > 0 && ', '}
+                  <Link
+                    href={`/blog/tags/${tag}`}
+                    className="normal-case hover:text-brand-red-bright"
+                  >
+                    {tag}
+                  </Link>
+                </span>
+              ))}
             </>
           )}
         </p>
@@ -88,37 +111,39 @@ export default async function PostPage({ params }: PostPageProps) {
         <MdxContent code={post.code} />
       </div>
 
-      <nav
-        aria-label="More Posts"
-        className="mt-brand-2xl flex justify-between gap-brand-m border-t border-brand-hairline pt-brand-m font-brand-mono text-brand-sm"
-      >
-        <div>
-          {older && (
-            <Link
-              href={older.permalink}
-              className="group text-brand-fog hover:text-brand-red-bright"
-            >
-              <span aria-hidden>←</span> older
-              <span className="mt-brand-3xs block text-brand-white group-hover:text-brand-red-bright">
-                {older.title}
-              </span>
-            </Link>
-          )}
-        </div>
-        <div className="text-right">
-          {newer && (
-            <Link
-              href={newer.permalink}
-              className="group text-brand-fog hover:text-brand-red-bright"
-            >
-              newer <span aria-hidden>→</span>
-              <span className="mt-brand-3xs block text-brand-white group-hover:text-brand-red-bright">
-                {newer.title}
-              </span>
-            </Link>
-          )}
-        </div>
-      </nav>
+      {publishedIndex >= 0 && (older || newer) && (
+        <nav
+          aria-label="More Posts"
+          className="mt-brand-2xl flex justify-between gap-brand-m border-t border-brand-hairline pt-brand-m font-brand-mono text-brand-sm"
+        >
+          <div>
+            {older && (
+              <Link
+                href={older.permalink}
+                className="group text-brand-fog hover:text-brand-red-bright"
+              >
+                <span aria-hidden>←</span> older
+                <span className="mt-brand-3xs block text-brand-white group-hover:text-brand-red-bright">
+                  {older.title}
+                </span>
+              </Link>
+            )}
+          </div>
+          <div className="text-right">
+            {newer && (
+              <Link
+                href={newer.permalink}
+                className="group text-brand-fog hover:text-brand-red-bright"
+              >
+                newer <span aria-hidden>→</span>
+                <span className="mt-brand-3xs block text-brand-white group-hover:text-brand-red-bright">
+                  {newer.title}
+                </span>
+              </Link>
+            )}
+          </div>
+        </nav>
+      )}
     </article>
   );
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -47,7 +47,7 @@ export default function BlogIndexPage() {
             <Link href={post.permalink} className="group block py-brand-m">
               <p className="font-brand-mono text-brand-xs text-brand-fog">
                 <span className="text-brand-red-bright">fig. {figNumber(index)}</span>
-                {' — '}
+                {' · '}
                 <time dateTime={post.date}>{formatDate(post.date)}</time>
                 {' · '}
                 {Math.max(1, Math.round(post.metadata.readingTime))} min

--- a/src/app/blog/tags/[tag]/page.tsx
+++ b/src/app/blog/tags/[tag]/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { postsForTag, publishedTags } from '@/content/blog';
+
+interface TagPageProps {
+  params: Promise<{ tag: string }>;
+}
+
+/** One page per Tag that a published Post carries; a Draft-only Tag is a 404. */
+export function generateStaticParams() {
+  return publishedTags.map((tag) => ({ tag }));
+}
+
+export const dynamicParams = false;
+
+export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
+  const { tag } = await params;
+  if (!publishedTags.includes(tag)) return {};
+
+  const canonical = `/blog/tags/${tag}`;
+  const description = `Posts tagged ${tag} on Nick's rambles.`;
+  return {
+    title: `Tagged ${tag}`,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title: `Tagged ${tag} · iamnick.dev`,
+      description,
+      url: canonical,
+      type: 'website',
+    },
+  };
+}
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+
+export default async function TagPage({ params }: TagPageProps) {
+  const { tag } = await params;
+  const posts = postsForTag(tag);
+  if (posts.length === 0) notFound();
+
+  return (
+    <>
+      <p className="font-brand-mono text-brand-xs uppercase tracking-[0.22em] text-brand-red-bright">
+        Tagged
+      </p>
+      <h1 className="mt-brand-2xs text-brand-3xl font-semibold leading-[var(--text-brand-3xl--line-height)] tracking-tight">
+        <span className="brand-underline">#{tag}</span>
+      </h1>
+      <p className="mt-brand-s text-brand-base leading-[var(--text-brand-base--line-height)] text-brand-fog">
+        {posts.length} {posts.length === 1 ? 'post' : 'posts'}.{' '}
+        <Link href="/blog" className="text-brand-red-bright hover:underline">
+          Back to all posts
+        </Link>
+      </p>
+
+      <ul className="mt-brand-xl">
+        {posts.map((post) => (
+          <li key={post.slug} className="border-t border-brand-hairline">
+            <Link href={post.permalink} className="group block py-brand-m">
+              <p className="font-brand-mono text-brand-xs text-brand-fog">
+                <time dateTime={post.date}>{formatDate(post.date)}</time>
+                {' · '}
+                {Math.max(1, Math.round(post.metadata.readingTime))} min
+              </p>
+              <h2 className="mt-brand-3xs text-brand-xl font-semibold leading-[var(--text-brand-xl--line-height)] tracking-tight transition-colors group-hover:text-brand-red-bright">
+                {post.title}
+              </h2>
+              <p className="mt-brand-2xs max-w-[58ch] text-brand-sm leading-relaxed text-brand-fog">
+                {post.description}
+              </p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,17 +1,27 @@
 import type { MetadataRoute } from 'next';
 
-import { publishedPosts } from '@/content/blog';
+import { postsForTag, publishedPosts, publishedTags } from '@/content/blog';
 import { SITE_URL } from '@/lib/site';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  // Drafts never appear (publishedPosts is the single Draft-filtered read). Tag
-  // URLs join at Stage 5 once the tag pages exist — no entry points at a 404.
+  // Drafts never appear (publishedPosts is the single Draft-filtered read).
   const posts: MetadataRoute.Sitemap = publishedPosts.map((post) => ({
     url: `${SITE_URL}${post.permalink}`,
     lastModified: new Date(post.updated ?? post.date),
     changeFrequency: 'monthly',
     priority: 0.7,
   }));
+
+  // One entry per Tag on a published Post; freshest Post in the Tag drives lastMod.
+  const tags: MetadataRoute.Sitemap = publishedTags.map((tag) => {
+    const newest = postsForTag(tag)[0];
+    return {
+      url: `${SITE_URL}/blog/tags/${tag}`,
+      lastModified: new Date(newest.updated ?? newest.date),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    };
+  });
 
   const blogIndexModified = publishedPosts.length
     ? new Date(publishedPosts[0].updated ?? publishedPosts[0].date)
@@ -31,5 +41,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     ...posts,
+    ...tags,
   ];
 }

--- a/src/content/blog.test.ts
+++ b/src/content/blog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { allPosts, publishedPosts } from './blog';
+import { allPosts, postsForTag, publishedPosts, publishedTags, routablePosts } from './blog';
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}T/;
 
@@ -44,6 +44,53 @@ describe('content/blog', () => {
     for (const post of allPosts) {
       expect(post.metadata.readingTime, `${post.slug} readingTime`).toBeGreaterThan(0);
       expect(post.code.length, `${post.slug} compiled MDX`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('content/blog tags', () => {
+  it('lists only Tags carried by a published Post, unique and alphabetical', () => {
+    const publishedTagSet = new Set(publishedPosts.flatMap((post) => post.tags));
+    expect(new Set(publishedTags).size).toBe(publishedTags.length);
+    expect([...publishedTags].sort((a, b) => a.localeCompare(b))).toEqual([...publishedTags]);
+    for (const tag of publishedTags) expect(publishedTagSet.has(tag)).toBe(true);
+  });
+
+  it('never surfaces a Tag that only a Draft carries', () => {
+    const publishedTagSet = new Set(publishedPosts.flatMap((post) => post.tags));
+    const draftOnly = new Set(allPosts.filter((post) => post.draft).flatMap((post) => post.tags));
+    for (const tag of draftOnly) {
+      if (!publishedTagSet.has(tag)) expect(publishedTags).not.toContain(tag);
+    }
+  });
+
+  it('postsForTag returns published Posts carrying the Tag, and nothing for an unknown Tag', () => {
+    for (const tag of publishedTags) {
+      const forTag = postsForTag(tag);
+      expect(forTag.length, tag).toBeGreaterThan(0);
+      expect(
+        forTag.every((post) => !post.draft && post.tags.includes(tag)),
+        tag,
+      ).toBe(true);
+    }
+    expect(postsForTag('definitely-not-a-tag')).toHaveLength(0);
+  });
+});
+
+describe('content/blog Draft preview (routablePosts)', () => {
+  it('always routes every published Post', () => {
+    for (const post of publishedPosts) {
+      expect(routablePosts.map((p) => p.slug)).toContain(post.slug);
+    }
+  });
+
+  it('routes Drafts outside production while publishedPosts still hides them', () => {
+    // vitest runs with NODE_ENV=test, so the dev-preview branch is active. This
+    // pins the contract: a Draft is reachable at its URL locally, yet never
+    // appears in publishedPosts (the read behind index, tags, sitemap and feeds).
+    for (const draft of allPosts.filter((post) => post.draft)) {
+      expect(routablePosts.map((p) => p.slug)).toContain(draft.slug);
+      expect(publishedPosts.map((p) => p.slug)).not.toContain(draft.slug);
     }
   });
 });

--- a/src/content/blog.ts
+++ b/src/content/blog.ts
@@ -16,3 +16,26 @@ export const allPosts: readonly Post[] = posts;
 export const publishedPosts: readonly Post[] = [...posts]
   .filter((post) => !post.draft)
   .sort((a, b) => b.date.localeCompare(a.date));
+
+/** True in `next dev`; false in every production build (Vercel preview deploys
+ *  build with NODE_ENV=production too). Gates Draft preview and nothing else. */
+const previewingDrafts = process.env.NODE_ENV !== 'production';
+
+/**
+ * Posts whose `/blog/[slug]` route exists. Production is exactly publishedPosts;
+ * `next dev` also routes Drafts so the author can preview one at its URL. Read
+ * this ONLY for the Post route's params and lookup. The index, tag pages, sitemap
+ * and feeds stay on publishedPosts, so a Draft never leaks (handoff §4).
+ */
+export const routablePosts: readonly Post[] = previewingDrafts
+  ? [...posts].sort((a, b) => b.date.localeCompare(a.date))
+  : publishedPosts;
+
+/** Every Tag on a published Post, unique and alphabetical. A Draft-only Tag never appears. */
+export const publishedTags: readonly string[] = [
+  ...new Set(publishedPosts.flatMap((post) => post.tags)),
+].sort((a, b) => a.localeCompare(b));
+
+/** Published Posts carrying a Tag, newest-first (publishedPosts is already sorted). */
+export const postsForTag = (tag: string): readonly Post[] =>
+  publishedPosts.filter((post) => post.tags.includes(tag));


### PR DESCRIPTION
The last blog build stage. Adds tag pages, the dev-only Draft preview deferred from Stage 2, and the sitemap tag URLs Stage 4 held back. Every public read stays on `publishedPosts`, so the single-source Draft exclusion is unchanged.

## What's in it

- **Tag pages** — `/blog/tags/[tag]` over `publishedPosts`, brand-styled like the index (kicker, `#tag` with the dimension underline, post list). SSG per tag with `dynamicParams=false`, so an unknown or Draft-only tag 404s. Each page gets its own canonical and OpenGraph.
- **Tag accessors** — `publishedTags` and `postsForTag` in `src/content/blog.ts`, both reading `publishedPosts`. A Draft-only tag (like `process`, which only a Draft carries) never gets a page or a sitemap entry.
- **Tag links** — the Post meta row links each tag to its page. The index leaves tags as text, since the row is already a link and links cannot nest.
- **Draft preview** — `routablePosts` gates on `NODE_ENV`. In `next dev` a Draft is reachable at its URL with a "Draft, visible only in local development" banner and no `BlogPosting` JSON-LD. Production and Vercel preview builds exclude it. Only the Post route reads `routablePosts`; the index, tags, sitemap and feeds stay on `publishedPosts`.
- **Sitemap** — now emits `/blog/tags/[tag]` for every published tag.
- **Polish** — swapped the fig. meta separator from an em dash to a middot on the index and Post pages.

## Gates

- `pnpm validate` green: 167 unit tests (including the tag and Draft-preview accessors), knip clean, production build prerenders only the published tags (`agentic-workflows`, `meta`), not the Draft-only `process`.
- `@ci` e2e extended: tag page lists only its published Posts, unknown and Draft-only tags 404, Post tags link out, sitemap carries the tag URLs and not `process`.
- Verified live: a Draft is 200 in `next dev` (with banner) and 404 in the production build.

## Docs

Handoff and journal updated; new as-built summary at `docs/blog/blog-built.md`. This is the final build stage. After merge, the only remaining blog work is the authoring pipeline (`/publish-post` + `post-reviewer`), a separate workstream.

### Needs Nick
- **Merge** this to land the blog build.
- **OG card feel** (carried from #76) — the per-Post card now renders in real brand fonts but still has no look ruling. Not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)