### PR TITLE
Blog authoring pipeline — /publish-post skill + post-reviewer agent

### DIFF
--- a/.claude/agents/post-reviewer.md
+++ b/.claude/agents/post-reviewer.md
@@ -1,0 +1,71 @@
+---
+name: post-reviewer
+description: Read-only fact and SEO reviewer for blog Posts. Verifies every technical claim in a Post against the repo (cited paths exist, ADRs say what the Post claims, git history supports the narrative) and audits SEO and frontmatter quality. Use during /publish-post, or whenever a Post's claims need an independent check before merge. Never edits; returns findings with file:line and a POST verdict line.
+tools: Read, Bash, Glob, Grep
+---
+
+You are the post reviewer for iamnick.dev, a read-only fact-checker for blog
+Posts. The Posts are about this repo, so the repo is the fact source. You did
+not help write the prose, and that independence is the point: report what the
+evidence shows, not what the Post wants to be true.
+
+Input: a Post path (`content/blog/<slug>.mdx`). Read the whole file, then
+verify. Never edit anything.
+
+## What to check
+
+**Facts, every technical claim:**
+
+1. **Cited paths and identifiers exist.** Any file path, component, export,
+   script, or config key the Post names must exist in the repo at the claimed
+   location. Renamed or moved things are findings. The fact source is the
+   working tree of the checked-out branch; if a claim rests on an uncommitted
+   or untracked file, report it advisory with a note that the file must land
+   on master before or with the Post.
+2. **ADRs and specs say what the Post claims.** If the Post attributes a
+   decision to an ADR, read that ADR (`docs/adr/`) and confirm. Same for the
+   discovery decision log and the PRD (`docs/blog/`).
+3. **Git history supports the narrative.** "I did X then Y" claims must match
+   commit order (`git log --oneline --follow` on the touched files). Dates,
+   PR numbers and stage order are checkable; check them.
+4. **Numbers are real.** Test counts, bundle sizes, dates, version numbers:
+   verify against the repo or the named source. An unverifiable number is a
+   finding (advisory if plausible, blocking if contradicted).
+
+**SEO and frontmatter quality:**
+
+5. **Description** is 10 to 160 characters, reads as a meta description, and
+   matches what the Post actually says.
+6. **Title** is 3 to 99 characters and specific enough to stand alone in a
+   search result.
+7. **Heading structure** — the body starts at h2 (the page template owns the
+   h1), levels never skip, headings are descriptive. A short Post with no
+   headings at all is fine.
+8. **Internal links resolve.** Every relative link targets a route or anchor
+   that exists; every `/blog/...` link targets a published Post (a link to a
+   Draft will 404 in production). External links get a syntax sanity check
+   only, no fetching.
+9. **Frontmatter contract** — fields present and well-formed per
+   `velite.config.ts` (isodate `date`, slug matches filename, tags array).
+   Velite enforces this at build too; you catch it earlier with a clearer
+   message.
+
+## How to report
+
+One line per finding, with the Post's line number and the evidence:
+
+```
+content/blog/<slug>.mdx:41 — claims ADR-0009 covers the carnival HUD; ADR-0009 rescoped to brand-only (docs/adr/0009, "the live-HUD migration stage was DELETED")
+```
+
+Classify each finding **blocking** (a false claim, a dead link, a contract
+violation) or **advisory** (unverifiable but plausible, style-adjacent SEO
+nits). Judge prose meaning, not word-for-word matching; a paraphrase of a true
+thing is fine. A true-but-incomplete summary is a finding only when the
+omission would mislead a reader about how something works — Posts are not
+required to be exhaustive. Voice, register, and glossary terms are NOT yours — the voice
+pass and glossary-guard own those.
+
+End with exactly one verdict line, house format:
+
+`POST: CLEAN` or `POST: <n> findings (<m> blocking, <k> advisory)`

--- a/.claude/skills/publish-post/SKILL.md
+++ b/.claude/skills/publish-post/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: publish-post
+description: Editorial pipeline that takes a Draft blog Post from raw to publishable. Runs the structural check, the post-reviewer fact/SEO pass, the voice pass and the glossary pass, then stops for Nick to read the edited Draft. Publishing is Nick's merge, never automatic. Use when Nick says to publish, edit or run the pipeline on a Post.
+argument-hint: <slug> [--skip=structural|facts|voice|glossary|review]
+---
+
+# /publish-post — the editorial pipeline
+
+Take `content/blog/<slug>.mdx` (a Draft: `draft: true`) through the editing
+passes and up to the publish PR. ADR-0010 designed this; the spec is
+`docs/blog/agentic-workflow.md` Part 2. You are the conductor and Nick is the
+editor-in-chief: two human gates, and nothing merges itself.
+
+Order of operations is mechanical before judgmental, cheap before expensive.
+Any pass can be skipped with `--skip=<pass>`; say so in the changelog when one
+was. Track what every pass changes as you go — the changelog at gate 1 is
+built from it, and it is journal material.
+
+Rules that bind throughout: Nick drafts, AI edits, never ghost-writes. All
+edits move prose toward `docs/brand/voice.md`, never away. No em dashes, no
+setup-then-swerve, no template structures (the global writing rules apply to
+every line you touch).
+
+## 1. Structural pass (inline, fail fast)
+
+Read the Post and check before any prose work:
+
+- Frontmatter complete and well-formed per `velite.config.ts`: title 3–99
+  chars, description 10–160, isodate `date` (and `updated` if present),
+  `draft: true` still set, tags an array.
+- `slug` field agrees with the filename.
+- Tags checked against the existing vocabulary (union of tags across
+  `content/blog/*.mdx`). A NEW tag is a warning to raise with Nick, not an
+  error — the vocabulary stays deliberately small.
+- Reading-time sanity: run `pnpm content` and confirm the Post builds and its
+  derived reading time is plausible for the word count.
+
+Anything broken here stops the pipeline. Fix or ask; do not run prose passes
+over a Post that fails its contract.
+
+## 2. Fact + SEO pass (post-reviewer agent)
+
+Launch the **post-reviewer** agent (`.claude/agents/post-reviewer.md`) on the
+Post. It is read-only and independent; you apply the fixes it reports.
+
+- Fix blocking findings in the Post (or, where the Post is right and the doc
+  is stale, tell Nick — never silently rewrite history to match a doc).
+- Bring advisory findings to gate 1 rather than churning the prose over them.
+
+Runs before the voice pass on purpose: no point polishing sentences about to
+be rewritten for factual accuracy.
+
+## 3. Voice pass (avoid-ai-writing skill)
+
+Run the **avoid-ai-writing** skill edit-in-place on the Post with
+`docs/brand/voice.md` as the profile. This is the binding register: front-load
+the point, short declaratives, contractions, first person singular, dry
+British, the hard bans (no "we" for solo work, no emoji, no exclamation
+marks, no em dashes, no setup-then-swerve, no colon-list templates).
+
+Edit toward Nick's voice, never away from it. Where a sentence is already
+his, leave it alone — the pass removes AI tells, it does not impose style.
+
+## 4. Glossary pass (glossary-guard agent)
+
+Launch **glossary-guard** on the Post diff. Banned `_Avoid_` terms bite
+hardest in public prose ("resume", "journey", "category" for Tag, and the
+rest of `CONTEXT.md`). Apply blocking findings; carry advisory ones to
+gate 1.
+
+## 5. HUMAN GATE 1 — Nick reads the edited Draft
+
+Stop. Present:
+
+- The changelog: what each pass changed and why, pass by pass, plus anything
+  skipped and every advisory finding left open.
+- The edited Post (point at the file; quote only what needs a decision).
+
+Nick edits and approves. Do not proceed on silence, on your own judgment, or
+on anything short of his explicit go-ahead. His line-edits here are also the
+calibration input for `voice.md` — if they show a voice rule is wrong, update
+`docs/brand/voice.md` from what survives (never from taste).
+
+## 6. Ship
+
+Only after gate 1 approval:
+
+1. Flip `draft: false` (and set `updated` if the Post changed materially
+   since its `date`).
+2. Branch `post/<slug>` off fresh master; commit the Post.
+3. `pnpm validate` — the content build is the teeth; a contract violation
+   fails here.
+4. Run the **code-review** skill at LOW effort on the diff: it catches broken
+   MDX and embedded code, and skips prose nitpicking (prose was gates 1–4).
+5. Open the PR to master. The body carries the changelog from gate 1.
+
+## 7. HUMAN GATE 2 — publishing is the merge
+
+Nick merges the PR. Nothing auto-merges, ever. After the merge, offer to
+append a dated paragraph to `docs/blog/journal.md` if the pipeline run
+surfaced anything worth recording (a voice.md calibration, a new tag ruling,
+a pass that earned or failed to earn its keep).
+
+## Standing review
+
+After three published Posts, review the pipeline: any pass that has not
+changed an outcome gets deleted, and the pruning is itself a Post
+(`docs/blog/agentic-workflow.md` Part 4, risk 3).

--- a/docs/blog/agentic-workflow.md
+++ b/docs/blog/agentic-workflow.md
@@ -2,7 +2,7 @@
 
 > Design doc and learning artefact (ADR-0010). Two pipelines: the **build workflow** that delivers the blog feature, and the **authoring workflow** that ships each post afterwards. For every mechanism choice this doc records the reasoning **and the simpler alternative that was rejected** — the point is to learn when each tool earns its complexity, not just to use them.
 >
-> Drafted 2026-07-16 during discovery. The `.claude` components described here are designed, not yet built; they are created during the build stages, never before they are needed.
+> Drafted 2026-07-16 during discovery. The `.claude` components described here were built on 2026-07-23 (`feature/blog-authoring-pipeline`), after the build stages shipped and only once they were needed. This doc remains the design record; the components themselves live under `.claude/`.
 
 ## Principles
 

--- a/docs/blog/blog-built.md
+++ b/docs/blog/blog-built.md
@@ -6,8 +6,9 @@
 > contract that ties them together. Read this first; `docs/redesign/blog-handoff.md` behind it holds
 > the full build history, the stage-by-stage detail, and the gotchas.
 >
-> The one thing left is the **authoring pipeline** (`/publish-post` skill + `post-reviewer` agent).
-> That is how Posts get written and reviewed, a separate workstream, not a build stage. See §6.
+> The **authoring pipeline** (`/publish-post` skill + `post-reviewer` agent) is built too
+> (2026-07-23). That is how Posts get written and reviewed, a separate workstream from the surface
+> build. See §6 for how it is invoked.
 
 ---
 
@@ -151,19 +152,27 @@ All read `publishedPosts` and nothing else, so a Draft cannot enter a feed, site
 
 ---
 
-## 6. What remains: the authoring pipeline (separate workstream)
+## 6. The authoring pipeline (built, separate workstream)
 
-The blog **surface** is built. What is not built is how Posts get written and reviewed, specified in
-ADR-0010 and `docs/blog/agentic-workflow.md`:
+How Posts get written and reviewed, specified in ADR-0010 and `docs/blog/agentic-workflow.md`
+Part 2, **built 2026-07-23** (`feature/blog-authoring-pipeline`):
 
-- **`/publish-post` skill** — scaffold a Post from an idea, enforce the frontmatter contract, warn on
-  a new Tag (the vocabulary is kept deliberately small).
-- **`post-reviewer` agent** — a voice + `avoid-ai-writing` pass on a draft Post before Nick merges.
+- **`/publish-post <slug> [--skip=...]`** (`.claude/skills/publish-post/SKILL.md`) — the editorial
+  orchestrator over a Draft. Pass order: structural fail-fast (frontmatter contract, Tag-vocabulary
+  warning, `pnpm content`), the post-reviewer fact/SEO pass, the avoid-ai-writing voice pass
+  against `docs/brand/voice.md`, the glossary-guard pass, then human gate 1 (Nick reads the edited
+  Draft with a per-pass changelog), the ship step (flip `draft: false`, branch `post/<slug>`,
+  `pnpm validate`, low-effort code-review, PR) and human gate 2. Publishing is the merge; nothing
+  auto-merges.
+- **`post-reviewer` agent** (`.claude/agents/post-reviewer.md`) — read-only fact + SEO reviewer;
+  verifies every technical claim against the repo (the working tree is the fact source, untracked
+  files get an advisory caveat) and audits frontmatter/SEO quality. Findings carry file:line and
+  blocking/advisory severity under a `POST: CLEAN` / `POST: n findings` verdict line. Smoke-tested
+  against the `designing-the-publish-pipeline` Draft (3 advisory findings, one a genuine catch).
 
 These are the **only two** `.claude` components the blog is allowed (ADR-0010's two-component hard
-cap). Publishing stays Nick's act: Nick drafts, AI edits, publishing is Nick flipping `draft: false`
-and merging the PR. This work is Nick's to kick off, and it runs as its own workstream, not as
-another blog build stage.
+cap); a standing review after three published Posts deletes any pass that never changed an outcome.
+Publishing stays Nick's act: Nick drafts, AI edits, publishing is Nick merging the PR.
 
 ---
 

--- a/docs/blog/journal.md
+++ b/docs/blog/journal.md
@@ -82,3 +82,19 @@ to end the build on: the fig. separator moved from an em dash to a middot, the v
 even the punctuation between two numbers. The blog surface is complete. What is left, the
 `/publish-post` skill and the `post-reviewer` agent, is how Posts get written, a separate workstream,
 not another stage.
+
+**2026-07-23 — Authoring pipeline.** The workstream the build kept pointing at ran the same day
+Stage 5 merged, and it stayed inside its cap: two `.claude` components, the `/publish-post` skill
+and the `post-reviewer` agent, exactly the pair ADR-0010 allowed and nothing beyond it. The build
+itself was transcription from the workflow doc's Part 2, much as Stage 1 was transcription from the
+specs. The interesting part was the smoke test. Rather than trust the reviewer charter on paper, it
+was executed for real against the `designing-the-publish-pipeline` Draft, and it behaved like a
+reviewer should. The report came back in the right shape with the verdict `POST: 3 findings
+(0 blocking, 3 advisory)`, and one of those advisories was a catch genuinely worth having, because
+the Draft described pipeline components that were untracked files at the moment of review. The Post about the pipeline was,
+strictly, ahead of the repo it claimed to describe. That one run also exposed three ambiguities in
+the charter that a design read-through had never surfaced. The fact source, it turned out, needed
+saying: the working tree, with an advisory caveat for untracked files. A Post with no headings is
+fine, and a true-but-incomplete summary only counts as a finding when the omission would mislead.
+All three fixes went into the charter the same session. The pipeline's first real outing is still
+ahead; two seed Drafts are waiting for Nick to say `/publish-post`.

--- a/docs/redesign/blog-handoff.md
+++ b/docs/redesign/blog-handoff.md
@@ -5,9 +5,10 @@
 > Draft/Tag model and the single-read contract — read **`docs/blog/blog-built.md` first**; it is the
 > as-built summary. This handoff keeps the full build history and gotchas behind it.
 >
-> **What remains is not a build stage.** The authoring pipeline (`/publish-post` skill +
-> `post-reviewer` agent, ADR-0010) is a separate workstream: it is how Posts get written and
-> reviewed, not how the blog surface gets built. See §9.
+> **The authoring pipeline is built too** (2026-07-23, `feature/blog-authoring-pipeline`). The
+> `/publish-post` skill and the `post-reviewer` agent, the only two `.claude` components ADR-0010
+> allows, now exist and are invocable. They are how Posts get written and reviewed, not how the
+> blog surface gets built; they ran as their own workstream. See §1 and §9.
 >
 > Specs are done and live in `docs/blog/`; this doc points at them and adds only build-facing
 > operational detail. Read `CONTEXT.md` first (Blog/Post/Tag/Draft entries). Each stage got its
@@ -24,8 +25,8 @@
    ADR-0011; numbering preserved).
 3. Every stage was bracketed by carnival-context **Brief** before and **Absorb** after; Absorb also
    appends a dated paragraph to `docs/blog/journal.md`.
-4. Build complete (see §8, §9). What is left is the authoring pipeline, a separate workstream. Do
-   not duplicate spec content into code comments or this doc; the specs are the source.
+4. Build complete and the authoring pipeline built (see §8, §9). Do not duplicate spec content
+   into code comments or this doc; the specs are the source.
 
 ---
 
@@ -122,9 +123,27 @@
     extended `@ci` specs — `blog.spec.ts` (tag page renders its published Posts, unknown + Draft-only
     Tag 404, Post tags link out) and `blog-seo.spec.ts` (sitemap carries published Tag URLs, not
     `process`). Draft preview verified live: 200 + banner in `next dev`, 404 in the production build.
-- **Branch state**: Stage 4 merged to master as **PR #76**; Stage 2 was PR #74, Stage 1 PR #73,
-  Stage 0 PR #72. Master is green. Stage 5 sits on `feature/blog-stage-5` (commit 52f8411), awaiting
-  its PR to master.
+- **Authoring pipeline built** (2026-07-23, `feature/blog-authoring-pipeline`, commit 5308dfc):
+  the two `.claude` components ADR-0010 capped the design at.
+  `.claude/skills/publish-post/SKILL.md` is the `/publish-post` orchestrator, pass order per
+  `docs/blog/agentic-workflow.md` Part 2: structural fail-fast pass, post-reviewer fact/SEO pass,
+  avoid-ai-writing voice pass against `docs/brand/voice.md`, glossary-guard pass, human gate 1
+  (Nick reads the edited Draft, per-pass changelog presented), ship step (flip `draft: false`,
+  branch `post/<slug>`, `pnpm validate`, code-review at low effort, PR), human gate 2 (publishing
+  is the merge, nothing auto-merges). Passes are individually skippable via `--skip=`; a standing
+  review after three published Posts deletes any pass that never changed an outcome.
+  `.claude/agents/post-reviewer.md` is the read-only fact + SEO reviewer in the glossary-guard
+  house format (tools Read/Bash/Glob/Grep, file:line findings, blocking/advisory, verdict line
+  `POST: CLEAN` / `POST: n findings`). Smoke-tested for real: the reviewer charter ran against the
+  `designing-the-publish-pipeline` Draft and returned the correct report shape with verdict
+  `POST: 3 findings (0 blocking, 3 advisory)`, including a genuinely useful catch (the Draft
+  described pipeline components untracked at review time). Three charter ambiguities the smoke
+  test surfaced were fixed: the fact source is the working tree with an untracked-file advisory
+  caveat, a Post with no headings is fine, and a true-but-incomplete summary only counts when the
+  omission would mislead. Both components are registered and invocable.
+- **Branch state**: every build stage is on master. Stage 5 merged as **PR #77**, Stage 4 as
+  PR #76, Stage 2 PR #74, Stage 1 PR #73, Stage 0 PR #72. Master is green. The authoring pipeline
+  sits on `feature/blog-authoring-pipeline` (commit 5308dfc), awaiting its PR to master.
 
 ## 2. Integration map
 
@@ -261,7 +280,8 @@ first-load JS **budget** number (baseline recorded, §7).
 - **Brand monogram small-size pass done, ruling pending** — three variants rendered in
   `docs/brand/boards/monogram-pass.{html,png}`: V1 (heavier stems, dash kept), V2 (points, no
   dash — cleanest at 16px), V3 (measured cut — boldest at large, muddy ≤32px). Nick rules the
-  result (`docs/brand/brand.md` §Open refinements); blocks the Stage 2 merge.
+  result (`docs/brand/brand.md` §Open refinements). Stage 2 merged (PR #74) without the ruling,
+  so nothing blocks on it now; it stays tracked in brand.md, not here.
 - **"Career tickets" glossary gap** — glossary-guard advisory from the Stage 0 review; a
   carnival-side term, not blog work. Parked; do not fix under a blog branch.
 
@@ -274,61 +294,46 @@ first-load JS **budget** number (baseline recorded, §7).
 3. ~~**Stage 4 — SEO surfaces**~~ ✅ done (2026-07-23, `feature/blog-stage-4`): `generateMetadata`
    for index + Posts, per-Post OG card, `BlogPosting` JSON-LD, sitemap extension, RSS. Full gate
    green plus `e2e/blog-seo.spec.ts` 6/6. See §1.
-4. ~~**Stage 5 — tag pages + Draft polish**~~ ✅ done (2026-07-23, `feature/blog-stage-5`, commit
-   52f8411): `/blog/tags/[tag]` over `publishedPosts`, the draft-preview mechanism deferred from
-   Stage 2 (`routablePosts`, dev-only), then the sitemap tag URLs Stage 4 held back. `pnpm validate`
-   green (167 unit), `@ci` blog + SEO specs extended and passing. See §1, §9. Shipped-state summary
-   written to `docs/blog/blog-built.md`.
+4. ~~**Stage 5 — tag pages + Draft polish**~~ ✅ done and merged as **PR #77** (2026-07-23,
+   `feature/blog-stage-5`, commit 52f8411): `/blog/tags/[tag]` over `publishedPosts`, the
+   draft-preview mechanism deferred from Stage 2 (`routablePosts`, dev-only), then the sitemap tag
+   URLs Stage 4 held back. `pnpm validate` green (167 unit), `@ci` blog + SEO specs extended and
+   passing. See §1, §9. Shipped-state summary written to `docs/blog/blog-built.md`.
 
-**The blog build is COMPLETE** — Stages 0, B, 1, 2, 4, 5 all shipped (Stage 3 deleted, ADR-0011).
-Every stage ran carnival-context Brief before, Absorb after, journal paragraph appended to
-`docs/blog/journal.md`, branch per stage, PR to master. What remains is the authoring pipeline (§9),
-a separate workstream, not a build stage.
+**The blog build is COMPLETE** — Stages 0, B, 1, 2, 4, 5 all shipped and merged (Stage 3 deleted,
+ADR-0011). Every stage ran carnival-context Brief before, Absorb after, journal paragraph appended
+to `docs/blog/journal.md`, branch per stage, PR to master. The authoring pipeline followed as its
+own workstream and is now built too (§1, §9).
 
 ## 9. What just happened
 
-**Stage 5 built and gated, the final build stage** (2026-07-23, `feature/blog-stage-5`, commit
-52f8411). Tag pages, the Draft preview deferred from Stage 2, and the sitemap tag URLs Stage 4 held
-back all landed together, each still resolving through the single `publishedPosts` read. The tag
-route (`src/app/blog/tags/[tag]/page.tsx`) is brand-styled like the index, SSG over `publishedTags`
-with `dynamicParams = false`, so an unknown or Draft-only Tag 404s and each Tag page carries its own
-canonical + OpenGraph. Post meta-row Tags now link out; the index leaves them as text because the
-whole row is already a Post link and a link cannot nest. The Draft preview is a dev-only affordance:
-`routablePosts` gates on `NODE_ENV`, the Post route alone reads it, and a Draft shows at its URL in
-`next dev` with a banner and no JSON-LD while production and Vercel preview builds exclude it. The
-sitemap now emits every published Tag URL, and the fig. meta separator moved from an em dash to a
-middot to hold the voice rule. Gate green: `pnpm validate` (167 unit, knip clean, build prerenders
-only published surfaces), the extended `@ci` blog + SEO specs, and a live check that the Draft is 200
+**PR #77 merged** (2026-07-23): Stage 5 landed on master, closing the blog build. Stages 0, B, 1,
+2, 4, 5 are all shipped and merged (Stage 3 deleted under ADR-0011). The public surface is done on
+the single-read contract; the as-built summary is `docs/blog/blog-built.md`, read it first from
+here on. Stage 5's build detail lives in §1 and §8.
 
-- banner in `next dev` and 404 in the production build.
-
-Also folded in this day: the **Stage 4 OG-card follow-up**. The per-Post card was re-cut to render in
-the real brand fonts (Montserrat wordmark, Plex Sans title, Plex Mono labels, all vendored as local
-woff in `src/assets/fonts/`) with explicit px widths so the title wraps as a sentence. Satori cannot
-read Tailwind or the `@theme` tokens, so Nick ruled the card stays all-inline (§7).
-
-**The blog build is now COMPLETE** — Stages 0, B, 1, 2, 4, 5 all shipped (Stage 3 deleted under
-ADR-0011). The public surface is done: index, Post reading template, tag pages, Draft preview, and
-the full SEO/discovery/social set, all on the single-read contract. The as-built summary is
-`docs/blog/blog-built.md`; read it first from here on.
-
-**What is left is the authoring pipeline, and it is a separate workstream, not a build stage.**
-ADR-0010 specifies a `/publish-post` skill (scaffold a Post from an idea, enforce the frontmatter
-contract, warn on a new Tag) and a `post-reviewer` agent (voice + `avoid-ai-writing` pass on a draft
-Post before Nick merges). Neither is built. They are how Posts get _written and reviewed_, not how
-the blog surface gets _built_, so they sit outside the staged build and outside this handoff's remit.
-The two-component hard cap (ADR-0010) means these are the only two `.claude` components the blog is
-allowed. `docs/blog/agentic-workflow.md` holds the spec.
+**The authoring pipeline is built** (2026-07-23, `feature/blog-authoring-pipeline`, commit
+5308dfc). Its own workstream, not a build stage: the `/publish-post` skill and the `post-reviewer`
+agent now exist under `.claude/`, the only two components ADR-0010's hard cap allows, built to the
+spec in `docs/blog/agentic-workflow.md` Part 2 (whose header now records them as built). Full
+component shape in §1. The smoke test earned its keep: running the reviewer charter against the
+`designing-the-publish-pipeline` Draft produced the correct report shape, the verdict `POST: 3
+findings (0 blocking, 3 advisory)`, and one genuinely useful advisory (the Draft described
+pipeline components that were untracked at review time). Three charter ambiguities the smoke test
+surfaced were fixed in the charter itself: the fact source is the working tree with an
+untracked-file advisory caveat, a Post with no headings is fine, and a true-but-incomplete summary
+only counts when the omission would mislead. Both components are registered and invocable; the
+branch awaits its PR to master.
 
 ### Needs Nick
 
-- **OG card feel** — the per-Post social card now renders in the real brand fonts, but the
-  composition still has no explicit look ruling. When Nick has a moment, check a live card
-  (`/blog/building-this-blog-in-the-open/opengraph-image`) and say whether it holds. Not a blocker; a
-  share preview is off the critical path, but it is a public visual surface and the feel is Nick's
-  call.
-- **Merge `feature/blog-stage-5`** — Stage 5 is gated green on its branch and awaits its PR to
-  master (the last build PR). Merging it is Nick's, as every stage merge has been.
-- **Kick off the authoring pipeline when ready** — building `/publish-post` + `post-reviewer` is the
-  next natural piece of work, but it is Nick's call when to start it and it runs as its own workstream
-  under ADR-0010, not as a blog build stage.
+- **Run `/publish-post <slug>` on a Draft when ready** — the pipeline is live; the two seed Drafts
+  (`designing-the-publish-pipeline`, `speccing-before-scaffolding`) are the natural candidates.
+  Publishing stays Nick's merge at gate 2, as ADR-0010 rules. The pipeline branch
+  (`feature/blog-authoring-pipeline`) also awaits its PR to master; merging it is Nick's, as every
+  merge has been.
+- **OG card feel** — still open. The per-Post social card renders in the real brand fonts, but the
+  composition has no explicit look ruling. When Nick has a moment, check a live card
+  (`/blog/building-this-blog-in-the-open/opengraph-image`) and say whether it holds. Not a blocker;
+  a share preview is off the critical path, but it is a public visual surface and the feel is
+  Nick's call.


### PR DESCRIPTION
The per-Post editorial workstream that follows the completed build stages. Exactly the two `.claude` components ADR-0010 capped the design at, nothing more.

## What's in it

- **`.claude/skills/publish-post/SKILL.md`** — the `/publish-post <slug>` orchestrator, spec order from `docs/blog/agentic-workflow.md` Part 2. Structural fail-fast pass, post-reviewer fact/SEO pass, avoid-ai-writing voice pass against `docs/brand/voice.md`, glossary-guard pass. Then human gate 1: the skill stops with a per-pass changelog and waits for Nick to read the edited Draft. Ship flips `draft: false`, branches `post/<slug>`, runs `pnpm validate` and a low-effort code review, and opens the PR. Human gate 2 is the merge; nothing auto-merges. Every pass is skippable via `--skip=`, and a standing review after three published Posts deletes any pass that never changed an outcome.
- **`.claude/agents/post-reviewer.md`** — the read-only fact and SEO reviewer, glossary-guard house format: Read/Bash/Glob/Grep only, file:line findings, blocking/advisory split, `POST: CLEAN` / `POST: n findings` verdict line. The Posts are about this repo, so the repo is the fact source.

## Verified

Smoke-tested for real: the reviewer charter ran against the `designing-the-publish-pipeline` Draft and returned the correct report shape with `POST: 3 findings (0 blocking, 3 advisory)`, including a genuinely useful catch (the Draft describes components that were untracked at review time). Three charter ambiguities the smoke test surfaced were fixed before commit: working-tree fact source with an untracked-file caveat, no-headings Posts are fine, and incomplete summaries only count when misleading. Both components registered live in the session. Lint and knip green.

## Docs

`agentic-workflow.md` header, handoff, `blog-built.md` and the journal all updated: the pipeline is recorded as built, and the stale post-#77 branch-state lines are settled.

### Needs Nick
- **Merge** to land the pipeline.
- **First run** — `/publish-post` on a Draft when you're ready; `designing-the-publish-pipeline` and `speccing-before-scaffolding` are the candidates.
- Carried: the soft OG-card look ruling, and the monogram small-size ruling tracked in `brand.md` (neither blocks anything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)